### PR TITLE
Make pyexiv2 optional and lazy-load EXIF support

### DIFF
--- a/pinterest_dl/storage/media.py
+++ b/pinterest_dl/storage/media.py
@@ -6,16 +6,51 @@ Separated from the data model to maintain clear separation of concerns.
 """
 
 from pathlib import Path
-from typing import Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-import pyexiv2
 from PIL import Image
 
 from pinterest_dl.common.logging import get_logger
 from pinterest_dl.domain.media import PinterestMedia
 from pinterest_dl.exceptions import UnsupportedMediaTypeError
 
+if TYPE_CHECKING:
+    import pyexiv2
+
 logger = get_logger(__name__)
+
+# Module-level lazy import for pyexiv2 (checked only once)
+_pyexiv2: Optional[Any] = None
+_pyexiv2_available: Optional[bool] = None
+
+
+def _get_pyexiv2() -> Any:
+    """Lazy import pyexiv2, caching the result.
+
+    Returns:
+        pyexiv2 module if available.
+
+    Raises:
+        ImportError: If pyexiv2 is not installed.
+    """
+    global _pyexiv2, _pyexiv2_available
+
+    if _pyexiv2_available is None:
+        try:
+            import pyexiv2
+
+            _pyexiv2 = pyexiv2
+            _pyexiv2_available = True
+        except ImportError:
+            _pyexiv2_available = False
+
+    if not _pyexiv2_available:
+        raise ImportError(
+            "pyexiv2 is required for EXIF operations. "
+            "Install it with: pip install pyexiv2"
+        )
+
+    return _pyexiv2
 
 
 def set_local_resolution(media: PinterestMedia, path: Path) -> None:
@@ -92,7 +127,10 @@ def write_exif_comment(media: PinterestMedia, comment: str) -> None:
 
     Raises:
         ValueError: If local path is not set.
+        ImportError: If pyexiv2 is not installed.
     """
+    pyexiv2 = _get_pyexiv2()
+
     if not media.local_path:
         raise ValueError("Local path not set.")
 
@@ -109,7 +147,10 @@ def write_exif_subject(media: PinterestMedia, subject: str) -> None:
 
     Raises:
         ValueError: If local path is not set.
+        ImportError: If pyexiv2 is not installed.
     """
+    pyexiv2 = _get_pyexiv2()
+
     if not media.local_path:
         raise ValueError("Local path not set.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "selenium>=4.26.1",
     "pillow==10.4.0",
     "tqdm",
-    "pyexiv2",
     "requests",
     "deprecated",
     "m3u8",
@@ -32,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0.0", "pytest-mock>=3.10.0"]
+exif = ["pyexiv2"]
 
 [project.scripts]
 pinterest-dl = "pinterest_dl.cli:main"


### PR DESCRIPTION
Lazy-import and cache pyexiv2 in storage/media; EXIF helpers now raise ImportError with an install suggestion when unavailable. Remove pyexiv2 from core dependencies and add an "exif" optional extra in pyproject.toml.