### PR TITLE
feat: scrape one

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,17 +122,20 @@ pip install .[all]
 Scrape images from Pinterest using the command line:
 
 ```bash
-# Scrape from a Pinterest board or pin
+# Scrape a board, section, or the requested pin itself
 pinterest-dl scrape <url> -o output_folder -n 50
 
 # Download exactly one pin
 pinterest-dl one <pin_url> -o output_folder
 
+# Download pins related to a pin
+pinterest-dl related <pin_url> -o output_folder -n 50
+
 # Download videos as MP4 (requires ffmpeg)
-pinterest-dl one <pin_url> --video -o output_folder
+pinterest-dl scrape <pin_url> --video -o output_folder
 
 # Download videos as raw .ts files (no ffmpeg needed)
-pinterest-dl one <pin_url> --video --skip-remux -o output_folder
+pinterest-dl scrape <pin_url> --video --skip-remux -o output_folder
 
 # Search for images
 pinterest-dl search "nature photography" -o output_folder -n 30
@@ -143,7 +146,7 @@ pinterest-dl login -o cookies.json
 
 **📖 [View Full CLI Documentation ->](https://github.com/sean1832/pinterest-dl/blob/main/doc/CLI.md)**
 
-Available commands: `login`, `scrape`, `one`, `search`, `download`
+Available commands: `login`, `scrape`, `related`, `one`, `search`, `download`
 
 ---
 
@@ -156,9 +159,16 @@ from pinterest_dl import PinterestDL
 
 # Quick scrape and download
 images = PinterestDL.with_api().scrape_and_download(
-    url="https://www.pinterest.com/pin/1234567",
+    url="https://www.pinterest.com/username/board-name/",
     output_dir="images/art",
     num=30
+)
+
+# Download the requested pin itself
+pin = PinterestDL.with_api().scrape_and_download(
+    url="https://www.pinterest.com/pin/1234567",
+    output_dir="images/pin",
+    num=1
 )
 
 # Search for images

--- a/README.md
+++ b/README.md
@@ -125,11 +125,14 @@ Scrape images from Pinterest using the command line:
 # Scrape from a Pinterest board or pin
 pinterest-dl scrape <url> -o output_folder -n 50
 
+# Download exactly one pin
+pinterest-dl one <pin_url> -o output_folder
+
 # Download videos as MP4 (requires ffmpeg)
-pinterest-dl scrape <url> --video -o output_folder
+pinterest-dl one <pin_url> --video -o output_folder
 
 # Download videos as raw .ts files (no ffmpeg needed)
-pinterest-dl scrape <url> --video --skip-remux -o output_folder
+pinterest-dl one <pin_url> --video --skip-remux -o output_folder
 
 # Search for images
 pinterest-dl search "nature photography" -o output_folder -n 30
@@ -140,7 +143,7 @@ pinterest-dl login -o cookies.json
 
 **📖 [View Full CLI Documentation ->](https://github.com/sean1832/pinterest-dl/blob/main/doc/CLI.md)**
 
-Available commands: `login`, `scrape`, `search`, `download`
+Available commands: `login`, `scrape`, `one`, `search`, `download`
 
 ---
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -33,7 +33,7 @@ You can use the `PinterestDL` class directly in your Python code to scrape and d
 
 ### Scrape from URL
 
-This example shows how to **scrape** and download images from a Pinterest URL in one step.
+This example shows how to **scrape** and download media from a Pinterest URL in one step.
 
 ```python
 from pinterest_dl import PinterestDL
@@ -45,7 +45,7 @@ images = PinterestDL.with_api(
     ensure_alt=True,  # Ensure every image has alt text (default: False)
     dump=None,  # Dump API requests/responses to directory (default: None/disabled)
 ).scrape_and_download(
-    url="https://www.pinterest.com/pin/1234567",  # Pinterest URL to scrape
+    url="https://www.pinterest.com/username/board-name/",  # Board, section, or pin URL to scrape
     output_dir="images/art",  # Directory to save downloaded images
     num=30,  # Max number of images to download 
     download_streams=True,  # Download video streams if available (default: False)
@@ -130,7 +130,7 @@ images = (
         cookies,  # cookies in selenium format
     )
     .scrape_and_download(
-        url="https://www.pinterest.com/pin/1234567",  # Assume this is a private board URL
+        url="https://www.pinterest.com/username/private-board/",  # Private board or pin URL
         output_dir="images/art",  # Directory to save downloaded images
         num=30,  # Max number of images to download
     )
@@ -153,8 +153,9 @@ import json
 from pinterest_dl import PinterestDL
 
 # 1. Initialize PinterestDL with API and scrape media
+# Pin URLs return the requested pin itself. Use `.related(...)` for recommendations around a pin.
 scraped_medias = PinterestDL.with_api().scrape(
-    url="https://www.pinterest.com/pin/1234567",  # URL of the Pinterest page
+    url="https://www.pinterest.com/username/board-name/",  # URL of the Pinterest page
     num=30,  # Maximum number of images to scrape
     min_resolution=(512, 512),  # <- Only available to set in the API. Browser mode will have to pruned after download.
 )

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -9,8 +9,9 @@ pinterest-dl [command] [options]
 | ------------------------- | ---------------------------------------------------------------------------------- |
 | [`login`](#1-login)       | Login to Pinterest to obtain browser cookies for scraping private boards and pins. |
 | [`scrape`](#2-scrape)     | Scrape images from a Pinterest URL.                                                |
-| [`search`](#3-search)     | Search for images on Pinterest using a query.                                      |
-| [`download`](#4-download) | Download images from a list of URLs provided in a JSON file.                       |
+| [`one`](#3-one)           | Download exactly one Pinterest pin.                                                |
+| [`search`](#4-search)     | Search for images on Pinterest using a query.                                      |
+| [`download`](#5-download) | Download images from a list of URLs provided in a JSON file.                       |
 
 
 ---
@@ -82,7 +83,39 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 
 ---
 
-### 3. Search  
+### 3. One
+Download exactly one Pinterest pin.
+
+```bash
+pinterest-dl one <pin_url> [options]
+
+# Aliases:
+pinterest-dl scrape_one <pin_url> [options]
+pinterest-dl scrape-one <pin_url> [options]
+```
+
+| Options                              | Description                                               | Default        |
+| ------------------------------------ | --------------------------------------------------------- | -------------- |
+| `<pin_url>`                          | Pinterest pin URL                                         | -              |
+| `-o`, `--output [directory]`         | Directory to save media (stdout if omitted)               | -              |
+| `-c`, `--cookies [file]`             | Path to cookies file (for private content)                | `cookies.json` |
+| `-r`, `--resolution [WxH]`           | Minimum image resolution                                  | -              |
+| `--video`                            | Download video stream (if available)                      | -              |
+| `--skip-remux` (**NEW**)             | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed) | -              |
+| `--timeout [seconds]`                | Request timeout                                           | `10`           |
+| `--cache [path]`                     | Save scraped URLs to JSON                                 | -              |
+| `--caption [txt/json/metadata/none]` | Caption format                                            | `none`         |
+| `--ensure-cap`                       | Require alt text on the pin                               | -              |
+| `--cap-from-title`                   | Use image title as caption                                | -              |
+| `--dump [PATH]` (**NEW**)            | Dump API requests/responses to PATH (default: `.dump`)    | -              |
+| `--verbose`                          | Enable debug output                                       | -              |
+
+> [!TIP]
+> Use `one` when you want the exact requested pin. Use `scrape` on a pin URL to fetch related pins.
+
+---
+
+### 4. Search  
 Find and download images via a search query (API mode only), or from URL-lists in files.
 
 ```bash
@@ -120,7 +153,7 @@ cat queries.txt | pinterest-dl search -f - [options]
 
 ---
 
-### 4. Download  
+### 5. Download  
 Fetch images from a previously saved cache file.
 
 ```bash

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -8,10 +8,11 @@ pinterest-dl [command] [options]
 | Command                   | Description                                                                        |
 | ------------------------- | ---------------------------------------------------------------------------------- |
 | [`login`](#1-login)       | Login to Pinterest to obtain browser cookies for scraping private boards and pins. |
-| [`scrape`](#2-scrape)     | Scrape images from a Pinterest URL.                                                |
-| [`one`](#3-one)           | Download exactly one Pinterest pin.                                                |
-| [`search`](#4-search)     | Search for images on Pinterest using a query.                                      |
-| [`download`](#5-download) | Download images from a list of URLs provided in a JSON file.                       |
+| [`scrape`](#2-scrape)     | Download the requested pin or scrape a board/section URL.                          |
+| [`related`](#3-related)   | Download pins related to a specific Pinterest pin.                                 |
+| [`one`](#4-one)           | Download exactly one Pinterest pin.                                                |
+| [`search`](#5-search)     | Search for images on Pinterest using a query.                                      |
+| [`download`](#6-download) | Download images from a list of URLs provided in a JSON file.                       |
 
 
 ---
@@ -43,7 +44,7 @@ pinterest-dl login [options]
 ---
 
 ### 2. Scrape  
-Download images from a Pin, Board URL, or a list of URLs.
+Download the requested pin itself, or scrape a Board/Section URL.
 
 ```bash
 # Single or multiple URLs:
@@ -64,7 +65,7 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 | `<url>`                                     | One or more Pinterest URLs                                | -              |
 | `-o`, `--output [directory]`                | Directory to save images (stdout if omitted)              | -              |
 | `-c`, `--cookies [file]`                    | Path to cookies file (for private content)                | `cookies.json` |
-| `-n`, `--num [number]`                      | Maximum images to download                                | `100`          |
+| `-n`, `--num [number]`                      | Maximum images to download (`scrape` returns 1 for pin URLs) | `100`       |
 | `-r`, `--resolution [WxH]`                  | Minimum image resolution (e.g. `512x512`)                 | -              |
 | `--video`                                   | Download video stream (if available)                      | -              |
 | `--skip-remux` (**NEW**)                    | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed) | -              |
@@ -83,7 +84,39 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 
 ---
 
-### 3. One
+### 3. Related
+Download pins related to one or more Pinterest pins (API mode).
+
+```bash
+# Single or multiple pin URLs:
+pinterest-dl related <pin_url1> <pin_url2> ... [options]
+
+# From one or more files:
+pinterest-dl related -f urls.txt [options]
+```
+
+| Options                              | Description                                                 | Default        |
+| ------------------------------------ | ----------------------------------------------------------- | -------------- |
+| `-f`, `--file [file]`                | Path to file with URLs (one per line); use `-` for stdin    | -              |
+| `<pin_url>`                          | One or more Pinterest pin URLs                              | -              |
+| `-o`, `--output [directory]`         | Directory to save media (stdout if omitted)                 | -              |
+| `-c`, `--cookies [file]`             | Path to cookies file (for private content)                  | `cookies.json` |
+| `-n`, `--num [number]`               | Maximum related pins to download                            | `100`          |
+| `-r`, `--resolution [WxH]`           | Minimum image resolution                                    | -              |
+| `--video`                            | Download video stream (if available)                        | -              |
+| `--skip-remux` (**NEW**)             | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed)   | -              |
+| `--timeout [seconds]`                | Request timeout                                             | `10`           |
+| `--delay [seconds]`                  | Delay between requests                                      | `0.2`          |
+| `--cache [path]`                     | Save scraped URLs to JSON                                   | -              |
+| `--caption [txt/json/metadata/none]` | Caption format                                              | `none`         |
+| `--ensure-cap`                       | Require alt text on every image                             | -              |
+| `--cap-from-title`                   | Use image title as caption                                  | -              |
+| `--dump [PATH]` (**NEW**)            | Dump API requests/responses to PATH (default: `.dump`)      | -              |
+| `--verbose`                          | Enable debug output                                         | -              |
+
+---
+
+### 4. One
 Download exactly one Pinterest pin.
 
 ```bash
@@ -111,11 +144,11 @@ pinterest-dl scrape-one <pin_url> [options]
 | `--verbose`                          | Enable debug output                                       | -              |
 
 > [!TIP]
-> Use `one` when you want the exact requested pin. Use `scrape` on a pin URL to fetch related pins.
+> `scrape` and `one` both fetch the requested pin itself. Use `related` when you want Pinterest recommendations around a pin.
 
 ---
 
-### 4. Search  
+### 5. Search  
 Find and download images via a search query (API mode only), or from URL-lists in files.
 
 ```bash
@@ -153,7 +186,7 @@ cat queries.txt | pinterest-dl search -f - [options]
 
 ---
 
-### 5. Download  
+### 6. Download  
 Fetch images from a previously saved cache file.
 
 ```bash

--- a/doc/DUMP.md
+++ b/doc/DUMP.md
@@ -38,7 +38,7 @@ scraper = PinterestDL.with_api(
 )
 
 # All API calls will now be logged
-medias = scraper.scrape("https://pinterest.com/pin/123456/", num=10)
+medias = scraper.scrape("https://pinterest.com/pin/123456/", num=1)
 ```
 
 ## Dump File Structure

--- a/examples/advanced_control.py
+++ b/examples/advanced_control.py
@@ -27,7 +27,7 @@ def example_1_separate_scrape_and_download():
     # Step 1: Scrape media metadata
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=20,
+        num=1,
         min_resolution=(512, 512),
     )
 
@@ -53,7 +53,7 @@ def example_2_save_metadata_to_json():
     # Scrape media
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=15,
+        num=1,
     )
 
     # Convert to dictionary and save
@@ -76,7 +76,7 @@ def example_3_add_captions_as_metadata():
     # Scrape and download
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=10,
+        num=1,
     )
 
     output_dir = "downloads/advanced/with_metadata"
@@ -101,7 +101,7 @@ def example_4_add_captions_as_txt_files():
     # Scrape and download
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=10,
+        num=1,
     )
 
     output_dir = "downloads/advanced/with_txt"
@@ -126,7 +126,7 @@ def example_5_add_captions_as_json_files():
     # Scrape and download
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=10,
+        num=1,
     )
 
     output_dir = "downloads/advanced/with_json"
@@ -151,7 +151,7 @@ def example_6_prune_by_resolution():
     # Scrape and download (no resolution filter)
     scraped_medias = PinterestDL.with_api().scrape(
         url=PIN_URL,
-        num=20,
+        num=1,
     )
 
     output_dir = "downloads/advanced/prune"

--- a/examples/authentication_cookies.py
+++ b/examples/authentication_cookies.py
@@ -108,7 +108,7 @@ def example_3_use_cookies_path_directly():
         .scrape_and_download(
             url=PRIVATE_PIN_URL,
             output_dir="downloads/private_pin",
-            num=10,
+            num=1,
         )
     )
 

--- a/examples/basic_scraping.py
+++ b/examples/basic_scraping.py
@@ -16,7 +16,7 @@ BOARD_URL = "https://www.pinterest.com/username/board-name/"  # Replace with act
 
 
 def example_1_simple_pin_scrape():
-    """Scrape a single pin and download its images."""
+    """Scrape a single pin and download it."""
     print("Example 1: Simple Pin Scrape")
     print("-" * 50)
 
@@ -24,7 +24,7 @@ def example_1_simple_pin_scrape():
     images = PinterestDL.with_api().scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/pin",
-        num=10,
+        num=1,
     )
 
     if images:
@@ -64,7 +64,7 @@ def example_3_with_resolution_filter():
     images = PinterestDL.with_api().scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/high_res",
-        num=20,
+        num=1,
         min_resolution=(1024, 1024),  # Only download images >= 1024x1024
     )
 
@@ -84,7 +84,7 @@ def example_4_with_captions():
     images = PinterestDL.with_api().scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/with_captions",
-        num=10,
+        num=1,
         caption="txt",  # Options: 'txt', 'json', 'metadata', 'none'
     )
 
@@ -103,7 +103,7 @@ def example_5_with_cache():
     images = PinterestDL.with_api().scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/cached",
-        num=15,
+        num=1,
         cache_path="cache/scraped_data.json",  # Save scraped metadata
     )
 
@@ -123,7 +123,7 @@ def example_6_with_video_streams():
     images = PinterestDL.with_api().scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/videos",
-        num=10,
+        num=1,
         download_streams=True,  # Download video streams as .mp4
     )
 
@@ -144,7 +144,7 @@ def example_7_verbose_mode():
     ).scrape_and_download(
         url=PIN_URL,
         output_dir="downloads/verbose",
-        num=5,
+        num=1,
     )
 
     if images:

--- a/examples/dump_mode.py
+++ b/examples/dump_mode.py
@@ -27,7 +27,7 @@ def example_1_basic_dump():
     scraper = PinterestDL.with_api(dump=".dump")
 
     # All API calls will be logged to ".dump/" directory
-    medias = scraper.scrape(PIN_URL, num=3)
+    medias = scraper.scrape(PIN_URL, num=1)
 
     print(f"> Scraped {len(medias)} items")
     print("> Dump files saved to: .dump/")
@@ -42,7 +42,7 @@ def example_2_custom_dump_dir():
     # Specify custom dump directory
     scraper = PinterestDL.with_api(dump="my_custom_dump")
 
-    medias = scraper.scrape(PIN_URL, num=2)
+    medias = scraper.scrape(PIN_URL, num=1)
 
     print(f"> Scraped {len(medias)} items")
     print("> Dump files saved to: my_custom_dump/")
@@ -74,7 +74,7 @@ def example_3_with_cookies():
         print("Note: No cookies file found (using public access)")
 
     # Scraping will dump request headers including cookies
-    medias = scraper.scrape(PIN_URL, num=2)
+    medias = scraper.scrape(PIN_URL, num=1)
 
     print(f"> Scraped {len(medias)} items")
     print("> Dump files with auth info saved to: auth_dump/")
@@ -90,7 +90,7 @@ def example_4_error_debugging():
 
     try:
         # Try scraping with an invalid URL (should fail)
-        scraper.scrape(INVALID_URL, num=2)
+        scraper.scrape(INVALID_URL, num=1)
     except Exception as e:
         print(f"x Error occurred: {e}")
         print("> Error dump file saved to: error_dump/")

--- a/examples/video_downloading.py
+++ b/examples/video_downloading.py
@@ -24,7 +24,7 @@ def example_1_basic_video_download():
     items = PinterestDL.with_api().scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/basic",
-        num=20,
+        num=1,
         download_streams=True,  # Enable video downloading
     )
 
@@ -43,7 +43,7 @@ def example_2_video_with_captions():
     items = PinterestDL.with_api().scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/with_captions",
-        num=15,
+        num=1,
         download_streams=True,
         caption="txt",  # Save descriptions to .txt files
     )
@@ -83,7 +83,7 @@ def example_4_video_with_json_metadata():
     items = PinterestDL.with_api().scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/with_json",
-        num=10,
+        num=1,
         download_streams=True,
         caption="json",  # Save full metadata
     )
@@ -105,7 +105,7 @@ def example_5_separate_video_scrape_and_download():
     # Step 1: Scrape media (includes video stream info)
     scraped_medias = PinterestDL.with_api().scrape(
         url=VIDEO_PIN_URL,
-        num=15,
+        num=1,
     )
 
     print(f"> Scraped {len(scraped_medias)} items")
@@ -134,7 +134,7 @@ def example_6_video_with_cache():
     items = PinterestDL.with_api().scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/cached",
-        num=20,
+        num=1,
         download_streams=True,
         cache_path="cache/video_metadata.json",  # Cache includes video info
     )
@@ -156,7 +156,7 @@ def example_7_video_with_resolution_preference():
     items = PinterestDL.with_api().scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/filtered",
-        num=25,
+        num=1,
         download_streams=True,
         min_resolution=(800, 600),  # Filter images by resolution
     )
@@ -179,7 +179,7 @@ def example_8_video_verbose_mode():
     ).scrape_and_download(
         url=VIDEO_PIN_URL,
         output_dir="downloads/videos/verbose",
-        num=10,
+        num=1,
         download_streams=True,
     )
 

--- a/pinterest_dl/__init__.py
+++ b/pinterest_dl/__init__.py
@@ -5,7 +5,7 @@ This package provides a simple API for scraping and downloading media from Pinte
 Example:
     >>> from pinterest_dl import PinterestDL
     >>> scraper = PinterestDL.with_api()
-    >>> media = scraper.scrape("https://pinterest.com/pin/123456/")
+    >>> media = scraper.scrape("https://pinterest.com/user/board/", num=10)
     >>> scraper.download(media, "output/")
 """
 

--- a/pinterest_dl/api/api.py
+++ b/pinterest_dl/api/api.py
@@ -1,5 +1,6 @@
 import re
 from typing import List, Optional, Tuple
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
@@ -40,7 +41,7 @@ class Api:
             timeout (float, optional): Request timeout in seconds. Defaults to 5.
             dump (Optional[str], optional): Directory to dump API requests/responses. Defaults to None (disabled).
         """
-        self.url = url
+        self.url = self._normalize_url(url)
         self.timeout = timeout
         self.dumper = RequestDumper(dump) if dump else None
         try:
@@ -82,6 +83,20 @@ class Api:
             {"x-pinterest-pws-handler": "www/pin/[id].js"}
         )  # required since 2025-03-07. See https://github.com/sean1832/pinterest-dl/issues/30
         self.is_pin = bool(self.pin_id)
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        """Normalize Pinterest URLs for both CLI and library callers."""
+        normalized = url.strip()
+        if not re.match(r"^https?://", normalized, flags=re.IGNORECASE):
+            normalized = f"https://{normalized}"
+
+        parsed = urlsplit(normalized)
+        path = parsed.path or "/"
+        if path != "/" and not path.endswith("/"):
+            path = f"{path}/"
+
+        return urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment))
 
     def get_related_images(self, num: int, bookmark: List[str]) -> PinResponse:
         if not self.pin_id:
@@ -186,6 +201,27 @@ class Api:
             raise requests.RequestException(f"Failed to request main image: {e}")
 
         return PinResponse(request_url, response_raw.json())
+
+    def get_pin_page(self) -> str:
+        """Fetch the public HTML for a pin page."""
+        if not self.pin_id:
+            raise ValueError("Invalid Pinterest URL")
+
+        request_url = self.url
+        headers = dict(self._session.headers)
+        headers.pop("x-pinterest-pws-handler", None)
+
+        try:
+            response_raw = self._session.get(
+                request_url,
+                timeout=self.timeout,
+                headers=headers,
+            )
+            response_raw.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise requests.RequestException(f"Failed to request pin page: {e}")
+
+        return response_raw.text
 
     def get_board(self) -> PinResponse:
         if not self.username or not self.boardname:
@@ -460,7 +496,7 @@ class Api:
 
     @staticmethod
     def _parse_pin_id(url: str) -> str:
-        result = re.search(r"pin/(\d+)/", url)
+        result = re.search(r"pin/(\d+)(?:/|$)", url)
         if not result:
             raise InvalidPinterestUrlError(f"Invalid Pinterest URL: {url}")
         return result.group(1)

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -52,6 +52,11 @@ def sanitize_url(url: str) -> str:
     return url if url.endswith("/") else url + "/"
 
 
+def looks_like_pin_url(url: str) -> bool:
+    """Return True when the URL path looks like a Pinterest pin URL."""
+    return "/pin/" in url
+
+
 def validate_cookies_authenticated(cookies: list[dict]) -> bool:
     """Check if cookies contain authenticated Pinterest session.
 
@@ -112,7 +117,7 @@ def get_parser() -> argparse.ArgumentParser:
     login_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
 
     # scrape command
-    scrape_cmd = cmd.add_parser("scrape", help="Scrape images from Pinterest")
+    scrape_cmd = cmd.add_parser("scrape", help="Download the requested pin or scrape a board/section")
     scrape_cmd.add_argument("urls", nargs="*", help="One or more URLs to scrape")
     scrape_cmd.add_argument("-f", "--file", action="append", help="Path to file with URLs (one per line), use '-' for stdin")
     scrape_cmd.add_argument("-o", "--output", type=str, help="Output directory")
@@ -134,6 +139,25 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("--backend", default="playwright", choices=["playwright", "selenium"], help="Browser backend for browser clients (default: playwright)")
     scrape_cmd.add_argument("--incognito", action="store_true", help="Incognito mode (only for browser clients)")
     scrape_cmd.add_argument("--headful", action="store_true", help="Run in headful mode with browser window (only for browser clients)")
+
+    # related command
+    related_cmd = cmd.add_parser("related", help="Download pins related to a Pinterest pin")
+    related_cmd.add_argument("urls", nargs="*", help="One or more Pinterest pin URLs")
+    related_cmd.add_argument("-f", "--file", action="append", help="Path to file with URLs (one per line), use '-' for stdin")
+    related_cmd.add_argument("-o", "--output", type=str, help="Output directory")
+    related_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private pins.")
+    related_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of related images to scrape (default: 100)")
+    related_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
+    related_cmd.add_argument("--video", action="store_true", help="Download video streams if available")
+    related_cmd.add_argument("--skip-remux", action="store_true", help="Skip ffmpeg remux, output raw .ts file (requires --video, no ffmpeg needed)")
+    related_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
+    related_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
+    related_cmd.add_argument("--cache", type=str, help="path to cache URLs into json file for reuse")
+    related_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
+    related_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
+    related_cmd.add_argument("--ensure-cap", action="store_true", help="Ensure every image has alt text")
+    related_cmd.add_argument("--cap-from-title", action="store_true", help="Use the image title as the caption")
+    related_cmd.add_argument("--dump", type=str, nargs="?", const=".dump", default=None, metavar="PATH", help="Dump API requests/responses to PATH directory (default: .dump if flag used without path, disabled if not specified)")
 
     # one command
     one_cmd = cmd.add_parser(
@@ -369,10 +393,57 @@ def main() -> None:
                             caption_from_title=args.cap_from_title,
                         )
                     )
-                    if imgs and len(imgs) != args.num:
-                        print(
-                            f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
-                        )
+                    expected_count = 1 if looks_like_pin_url(url) else args.num
+                    if imgs and len(imgs) != expected_count:
+                        if expected_count == 1:
+                            print(
+                                f"Warning: Expected 1 downloaded item from {url}, got {len(imgs)}."
+                            )
+                        else:
+                            print(
+                                f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
+                            )
+
+            print("\nDone.")
+        elif args.cmd == "related":
+            urls = combine_inputs(args.urls, args.file)
+            if not urls:
+                print("No URLs provided. Please provide at least one URL.")
+                return
+
+            if args.cookies:
+                check_and_warn_invalid_cookies(args.cookies)
+
+            for url in urls:
+                url = sanitize_url(url)
+                print(f"Scraping related pins from {url}...")
+                imgs = (
+                    PinterestDL.with_api(
+                        timeout=args.timeout,
+                        verbose=args.verbose,
+                        ensure_alt=args.ensure_cap,
+                        dump=args.dump,
+                    )
+                    .with_cookies_path(args.cookies)
+                    .related_and_download(
+                        url,
+                        args.output,
+                        args.num,
+                        download_streams=args.video,
+                        skip_remux=args.skip_remux,
+                        min_resolution=parse_resolution(args.resolution)
+                        if args.resolution
+                        else (0, 0),
+                        cache_path=args.cache,
+                        caption=args.caption,
+                        delay=args.delay,
+                        caption_from_title=args.cap_from_title,
+                    )
+                )
+                if imgs and len(imgs) != args.num:
+                    print(
+                        f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
+                    )
 
             print("\nDone.")
         elif args.cmd in ["one", "scrape_one", "scrape-one"]:

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -135,6 +135,26 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("--incognito", action="store_true", help="Incognito mode (only for browser clients)")
     scrape_cmd.add_argument("--headful", action="store_true", help="Run in headful mode with browser window (only for browser clients)")
 
+    # one command
+    one_cmd = cmd.add_parser(
+        "one",
+        aliases=["scrape_one", "scrape-one"],
+        help="Download exactly one Pinterest pin",
+    )
+    one_cmd.add_argument("url", help="Pinterest pin URL")
+    one_cmd.add_argument("-o", "--output", type=str, help="Output directory")
+    one_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private pins.")
+    one_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
+    one_cmd.add_argument("--video", action="store_true", help="Download video streams if available")
+    one_cmd.add_argument("--skip-remux", action="store_true", help="Skip ffmpeg remux, output raw .ts file (requires --video, no ffmpeg needed)")
+    one_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
+    one_cmd.add_argument("--cache", type=str, help="path to cache URLs into json file for reuse")
+    one_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
+    one_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
+    one_cmd.add_argument("--ensure-cap", action="store_true", help="Ensure the pin has alt text")
+    one_cmd.add_argument("--cap-from-title", action="store_true", help="Use the image title as the caption")
+    one_cmd.add_argument("--dump", type=str, nargs="?", const=".dump", default=None, metavar="PATH", help="Dump API requests/responses to PATH directory (default: .dump if flag used without path, disabled if not specified)")
+
     # search command
     search_cmd = cmd.add_parser("search", help="Search images from Pinterest")
     search_cmd.add_argument("querys", nargs="*", help="Search query")
@@ -353,6 +373,40 @@ def main() -> None:
                         print(
                             f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
                         )
+
+            print("\nDone.")
+        elif args.cmd in ["one", "scrape_one", "scrape-one"]:
+            url = sanitize_url(args.url)
+
+            if args.cookies:
+                check_and_warn_invalid_cookies(args.cookies)
+
+            print(f"Scraping one pin from {url}...")
+            imgs = (
+                PinterestDL.with_api(
+                    timeout=args.timeout,
+                    verbose=args.verbose,
+                    ensure_alt=args.ensure_cap,
+                    dump=args.dump,
+                )
+                .with_cookies_path(args.cookies)
+                .scrape_one_and_download(
+                    url,
+                    args.output,
+                    download_streams=args.video,
+                    skip_remux=args.skip_remux,
+                    min_resolution=parse_resolution(args.resolution)
+                    if args.resolution
+                    else (0, 0),
+                    cache_path=args.cache,
+                    caption=args.caption,
+                    caption_from_title=args.cap_from_title,
+                )
+            )
+            if imgs and len(imgs) != 1:
+                print(
+                    f"Warning: Expected 1 downloaded item from {url}, got {len(imgs)}."
+                )
 
             print("\nDone.")
         elif args.cmd == "search":

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Tuple, Union
@@ -10,9 +11,9 @@ from pinterest_dl.api.bookmark_manager import BookmarkManager
 from pinterest_dl.common import io
 from pinterest_dl.common.logging import get_logger
 from pinterest_dl.domain.cookies import CookieJar
-from pinterest_dl.domain.media import PinterestMedia
+from pinterest_dl.domain.media import PinterestMedia, VideoStreamInfo
 from pinterest_dl.download import request_builder
-from pinterest_dl.exceptions import EmptyResponseError
+from pinterest_dl.exceptions import EmptyResponseError, HttpResponseError
 from pinterest_dl.parsers.response import ResponseParser
 
 from . import operations
@@ -209,6 +210,51 @@ class ApiScraper:
             scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
         )
 
+    def scrape_one(
+        self,
+        url: str,
+        min_resolution: Tuple[int, int] = (0, 0),
+        caption_from_title: bool = False,
+    ) -> List[PinterestMedia]:
+        """Scrape exactly one requested pin from a pin URL."""
+        api = Api(
+            url,
+            self.cookies,
+            timeout=self.timeout,
+            dump=self.dump,
+        )
+
+        if not api.is_pin:
+            raise ValueError("scrape_one only supports Pinterest pin URLs")
+
+        media = self._scrape_one_pin(
+            api,
+            min_resolution,
+            caption_from_title=caption_from_title,
+        )
+        return [media] if media else []
+
+    def scrape_one_and_download(
+        self,
+        url: str,
+        output_dir: Optional[Union[str, Path]],
+        download_streams: bool = False,
+        skip_remux: bool = False,
+        min_resolution: Tuple[int, int] = (0, 0),
+        cache_path: Optional[Union[str, Path]] = None,
+        caption: Literal["txt", "json", "metadata", "none"] = "none",
+        caption_from_title: bool = False,
+    ) -> Optional[List[PinterestMedia]]:
+        """Download exactly one requested pin from a pin URL."""
+        scraped_outputs = self.scrape_one(
+            url,
+            min_resolution=min_resolution,
+            caption_from_title=caption_from_title,
+        )
+        return self._download_and_save(
+            scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
+        )
+
     def search(
         self,
         query: str,
@@ -362,7 +408,7 @@ class ApiScraper:
         bookmarks: BookmarkManager,
         caption_from_title: bool = False,
     ) -> List[PinterestMedia]:
-        """Scrape pins from a specific Pinterest pin URL."""
+        """Scrape related pins from a specific Pinterest pin URL."""
         images: List[PinterestMedia] = []
         remains = num
 
@@ -418,6 +464,201 @@ class ApiScraper:
                     raise
 
         return images
+
+    def _scrape_one_pin(
+        self,
+        api: Api,
+        min_resolution: Tuple[int, int],
+        caption_from_title: bool = False,
+    ) -> Optional[PinterestMedia]:
+        """Scrape the requested Pinterest pin from a pin URL."""
+        try:
+            return self._get_main_pin(
+                api,
+                min_resolution,
+                caption_from_title=caption_from_title,
+            )
+        except (ValueError, EmptyResponseError) as e:
+            logger.warning(f"Scraping interrupted: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error while scraping pin: {e}", exc_info=self.verbose)
+            raise
+
+    def _get_main_pin(
+        self,
+        api: Api,
+        min_resolution: Tuple[int, int],
+        caption_from_title: bool = False,
+    ) -> PinterestMedia:
+        """Fetch the requested pin from a pin URL."""
+        try:
+            response = api.get_main_image()
+            response_data = response.resource_response.get("data")
+            candidate_items = self._extract_pin_candidates(response_data)
+
+            if candidate_items:
+                matching_items = [
+                    item for item in candidate_items if str(item.get("id")) == str(api.pin_id)
+                ]
+                items_to_parse = matching_items or candidate_items
+
+                parsed_items = ResponseParser.from_responses(
+                    items_to_parse,
+                    min_resolution,
+                    caption_from_title=caption_from_title,
+                )
+
+                if self.ensure_alt:
+                    parsed_items = self._cull_no_alt(parsed_items)
+
+                if parsed_items:
+                    for item in parsed_items:
+                        if str(item.id) == str(api.pin_id):
+                            return item
+                    return parsed_items[0]
+        except HttpResponseError as e:
+            logger.debug(f"Pin API lookup failed, falling back to page HTML: {e}")
+        except EmptyResponseError:
+            logger.debug("Pin API lookup returned no pin data, falling back to page HTML")
+
+        return self._get_main_pin_from_page(
+            api,
+            min_resolution,
+            caption_from_title=caption_from_title,
+        )
+
+    def _extract_pin_candidates(self, data: Any) -> List[dict[str, Any]]:
+        """Collect pin-like dictionaries from a Pinterest API response."""
+        candidates: List[dict[str, Any]] = []
+
+        def visit(value: Any) -> None:
+            if isinstance(value, dict):
+                if value.get("id") is not None and value.get("images", {}).get("orig"):
+                    candidates.append(value)
+                for nested in value.values():
+                    visit(nested)
+            elif isinstance(value, list):
+                for nested in value:
+                    visit(nested)
+
+        visit(data)
+        return candidates
+
+    def _get_main_pin_from_page(
+        self,
+        api: Api,
+        min_resolution: Tuple[int, int],
+        caption_from_title: bool = False,
+    ) -> PinterestMedia:
+        """Parse pin metadata from the public pin page HTML."""
+        html = api.get_pin_page()
+        meta = self._extract_meta_tags(html)
+
+        src = (
+            meta.get("og:image")
+            or meta.get("twitter:image")
+            or meta.get("twitter:image:src")
+        )
+        if not src:
+            raise EmptyResponseError("No image found in pin page metadata.")
+
+        width = self._parse_int(meta.get("og:image:width"))
+        height = self._parse_int(meta.get("og:image:height"))
+        resolution = (width, height) if width and height else (0, 0)
+
+        min_width, min_height = min_resolution
+        if resolution != (0, 0) and (width < min_width or height < min_height):
+            raise EmptyResponseError("Requested pin does not meet min_resolution.")
+
+        description = meta.get("og:description") or meta.get("description") or ""
+        title = meta.get("og:title") or meta.get("twitter:title") or ""
+        alt = title if caption_from_title and title else description
+
+        if self.ensure_alt and not alt.strip():
+            raise EmptyResponseError("Requested pin has no alt text.")
+
+        video_stream = self._extract_video_stream_from_meta(meta) or self._extract_video_stream_from_html(html)
+
+        return PinterestMedia(
+            id=int(api.pin_id),
+            src=src,
+            alt=alt,
+            origin=api.url,
+            resolution=resolution,
+            video_stream=video_stream,
+        )
+
+    def _extract_meta_tags(self, html: str) -> dict[str, str]:
+        """Extract HTML meta tags into a lowercase key-value mapping."""
+        meta: dict[str, str] = {}
+
+        for tag in re.findall(r"<meta\b[^>]*>", html, flags=re.IGNORECASE):
+            attrs = {
+                key.lower(): value
+                for key, value in re.findall(
+                    r'([A-Za-z_:.-]+)\s*=\s*["\']([^"\']*)["\']',
+                    tag,
+                )
+            }
+            key = attrs.get("property") or attrs.get("name")
+            content = attrs.get("content")
+            if key and content:
+                meta[key.lower()] = content
+
+        return meta
+
+    def _extract_video_stream_from_meta(
+        self, meta: dict[str, str]
+    ) -> Optional[VideoStreamInfo]:
+        """Extract video metadata from page meta tags when available."""
+        video_url = meta.get("og:video") or meta.get("og:video:url")
+        if not video_url:
+            return None
+
+        width = self._parse_int(meta.get("og:video:width"))
+        height = self._parse_int(meta.get("og:video:height"))
+
+        return VideoStreamInfo(
+            url=video_url,
+            resolution=(width, height),
+            duration=0,
+        )
+
+    def _extract_video_stream_from_html(self, html: str) -> Optional[VideoStreamInfo]:
+        """Extract video URLs directly from raw page HTML."""
+        html = html.replace("\\/", "/")
+        candidates = re.findall(
+            r'https?://[^"\'<>\s]+(?:\.m3u8|\.mp4)(?:\?[^"\'<>\s]*)?',
+            html,
+            flags=re.IGNORECASE,
+        )
+        candidates = [
+            url
+            for url in candidates
+            if "pinimg.com" in url or "pinterest" in url
+        ]
+        if not candidates:
+            return None
+
+        def score(url: str) -> tuple[int, int]:
+            is_hls = 1 if ".m3u8" in url.lower() else 0
+            return (is_hls, len(url))
+
+        best_url = max(candidates, key=score)
+        return VideoStreamInfo(
+            url=best_url,
+            resolution=(0, 0),
+            duration=0,
+        )
+
+    def _parse_int(self, value: Optional[str]) -> int:
+        if value is None:
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
 
     def _scrape_board(
         self,

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -108,7 +108,7 @@ class ApiScraper:
 
         Args:
             url (str): Pinterest URL to scrape. Supports:
-                - Pin URL: scrapes related pins
+                - Pin URL: scrapes the requested pin itself
                 - Board URL: scrapes pins from the board
                 - Section URL: scrapes pins from a specific board section
             num (int): Maximum number of images to scrape.
@@ -119,24 +119,16 @@ class ApiScraper:
             List[PinterestMedia]: List of scraped PinterestMedia objects.
         """
 
+        api = self._create_api(url)
         medias: List[PinterestMedia] = []
-        api = Api(
-            url,
-            self.cookies,
-            timeout=self.timeout,
-            dump=self.dump,
-        )
-        bookmarks = BookmarkManager(3)
 
         if api.is_pin:
-            medias = self._scrape_pins(
+            media = self._scrape_one_pin(
                 api,
-                num,
                 min_resolution,
-                delay,
-                bookmarks,
                 caption_from_title=caption_from_title,
             )
+            medias = [media] if media else []
         elif api.is_section:
             # Section URL detected - scrape only this section
             medias = self._scrape_section(
@@ -152,7 +144,7 @@ class ApiScraper:
                 num,
                 min_resolution,
                 delay,
-                bookmarks,
+                BookmarkManager(3),
                 caption_from_title=caption_from_title,
             )
 
@@ -160,6 +152,36 @@ class ApiScraper:
             self._display_images(medias)
 
         logger.info(f"Successfully scraped {len(medias[:num])} media items from {url}")
+        return medias[:num]
+
+    def related(
+        self,
+        url: str,
+        num: int,
+        min_resolution: Tuple[int, int] = (0, 0),
+        delay: float = 0.2,
+        caption_from_title: bool = False,
+    ) -> List[PinterestMedia]:
+        """Scrape related pins from a Pinterest pin URL."""
+        api = self._create_api(url)
+        if not api.is_pin:
+            raise ValueError("related only supports Pinterest pin URLs")
+
+        medias = self._scrape_pins(
+            api,
+            num,
+            min_resolution,
+            delay,
+            BookmarkManager(3),
+            caption_from_title=caption_from_title,
+        )
+
+        if self.verbose:
+            self._display_images(medias)
+
+        logger.info(
+            f"Successfully scraped {len(medias[:num])} related media items from {url}"
+        )
         return medias[:num]
 
     def scrape_and_download(
@@ -179,7 +201,7 @@ class ApiScraper:
 
         Args:
             url (str): Pinterest URL to scrape. Supports:
-                - Pin URL: scrapes related pins
+                - Pin URL: scrapes the requested pin itself
                 - Board URL: scrapes pins from the board
                 - Section URL: scrapes pins from a specific board section
             output_dir (Optional[Union[str, Path]]): Directory to store downloaded images. 'None' print to console.
@@ -210,6 +232,31 @@ class ApiScraper:
             scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
         )
 
+    def related_and_download(
+        self,
+        url: str,
+        output_dir: Optional[Union[str, Path]],
+        num: int,
+        download_streams: bool = False,
+        skip_remux: bool = False,
+        min_resolution: Tuple[int, int] = (0, 0),
+        cache_path: Optional[Union[str, Path]] = None,
+        caption: Literal["txt", "json", "metadata", "none"] = "none",
+        caption_from_title: bool = False,
+        delay: float = 0.2,
+    ) -> Optional[List[PinterestMedia]]:
+        """Scrape related pins from a pin URL and download them."""
+        scraped_outputs = self.related(
+            url,
+            num,
+            min_resolution,
+            delay,
+            caption_from_title=caption_from_title,
+        )
+        return self._download_and_save(
+            scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
+        )
+
     def scrape_one(
         self,
         url: str,
@@ -217,12 +264,7 @@ class ApiScraper:
         caption_from_title: bool = False,
     ) -> List[PinterestMedia]:
         """Scrape exactly one requested pin from a pin URL."""
-        api = Api(
-            url,
-            self.cookies,
-            timeout=self.timeout,
-            dump=self.dump,
-        )
+        api = self._create_api(url)
 
         if not api.is_pin:
             raise ValueError("scrape_one only supports Pinterest pin URLs")
@@ -484,6 +526,14 @@ class ApiScraper:
         except Exception as e:
             logger.error(f"Unexpected error while scraping pin: {e}", exc_info=self.verbose)
             raise
+
+    def _create_api(self, url: str) -> Api:
+        return Api(
+            url,
+            self.cookies,
+            timeout=self.timeout,
+            dump=self.dump,
+        )
 
     def _get_main_pin(
         self,

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -478,7 +478,7 @@ class ApiScraper:
                 min_resolution,
                 caption_from_title=caption_from_title,
             )
-        except (ValueError, EmptyResponseError) as e:
+        except EmptyResponseError as e:
             logger.warning(f"Scraping interrupted: {e}")
             return None
         except Exception as e:
@@ -521,6 +521,8 @@ class ApiScraper:
             logger.debug(f"Pin API lookup failed, falling back to page HTML: {e}")
         except EmptyResponseError:
             logger.debug("Pin API lookup returned no pin data, falling back to page HTML")
+        except ValueError as e:
+            logger.debug(f"Pin API lookup returned invalid data, falling back to page HTML: {e}")
 
         return self._get_main_pin_from_page(
             api,
@@ -568,7 +570,11 @@ class ApiScraper:
         resolution = (width, height) if width and height else (0, 0)
 
         min_width, min_height = min_resolution
-        if resolution != (0, 0) and (width < min_width or height < min_height):
+        if (min_width > 0 or min_height > 0) and resolution == (0, 0):
+            raise EmptyResponseError(
+                "Requested pin does not include dimensions required for min_resolution."
+            )
+        if width < min_width or height < min_height:
             raise EmptyResponseError("Requested pin does not meet min_resolution.")
 
         description = meta.get("og:description") or meta.get("description") or ""

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -17,11 +17,15 @@ class TestPinterestAPIUrlParsing:
         assert api.pin_id == "123456789012345"
 
     def test_parse_pin_id_without_trailing_slash(self):
-        """Test parsing pin ID - URL needs trailing slash."""
-        # Note: The API requires trailing slash, so this will be None
+        """Test parsing pin ID when URL omits trailing slash."""
         api = Api("https://www.pinterest.com/pin/987654321098765")
-        # Without trailing slash, it won't parse
-        assert api.pin_id is None
+        assert api.pin_id == "987654321098765"
+
+    def test_parse_pin_id_without_scheme(self):
+        """Test parsing pin ID when URL omits scheme."""
+        api = Api("ru.pinterest.com/pin/47358233572860931/")
+        assert api.url == "https://ru.pinterest.com/pin/47358233572860931/"
+        assert api.pin_id == "47358233572860931"
 
     def test_parse_board_url_valid(self):
         """Test parsing board URL."""

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -1,5 +1,6 @@
 """Tests for Pinterest API URL parsing."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from pinterest_dl.api.api import Api
@@ -151,3 +152,64 @@ class TestScrapeOneFallbacks:
                 )
 
         assert items == []
+
+
+class TestApiScraperRouting:
+    def test_scrape_fetches_requested_pin_for_pin_urls(self):
+        fake_api = SimpleNamespace(is_pin=True, is_section=False)
+        expected = PinterestMedia(
+            id=123,
+            src="https://i.pinimg.com/originals/test.jpg",
+            alt="caption",
+            origin="https://www.pinterest.com/pin/123/",
+            resolution=(1200, 1800),
+        )
+
+        with (
+            patch("pinterest_dl.scrapers.api_scraper.Api", return_value=fake_api),
+            patch.object(ApiScraper, "_scrape_one_pin", return_value=expected) as scrape_one_pin,
+        ):
+            scraper = ApiScraper()
+            items = scraper.scrape("https://www.pinterest.com/pin/123/", num=50)
+
+        assert items == [expected]
+        scrape_one_pin.assert_called_once_with(
+            fake_api,
+            (0, 0),
+            caption_from_title=False,
+        )
+
+    def test_scrape_uses_board_flow_for_board_urls(self):
+        fake_api = SimpleNamespace(is_pin=False, is_section=False)
+        expected = [
+            PinterestMedia(
+                id=1,
+                src="https://i.pinimg.com/originals/test.jpg",
+                alt="caption",
+                origin="https://www.pinterest.com/pin/1/",
+                resolution=(1200, 1800),
+            )
+        ]
+
+        with (
+            patch("pinterest_dl.scrapers.api_scraper.Api", return_value=fake_api),
+            patch.object(ApiScraper, "_scrape_board", return_value=expected) as scrape_board,
+        ):
+            scraper = ApiScraper()
+            items = scraper.scrape("https://www.pinterest.com/user/board/", num=50)
+
+        assert items == expected
+        scrape_board.assert_called_once()
+
+    def test_related_requires_pin_urls(self):
+        fake_api = SimpleNamespace(is_pin=False, is_section=False)
+
+        with patch("pinterest_dl.scrapers.api_scraper.Api", return_value=fake_api):
+            scraper = ApiScraper()
+
+            try:
+                scraper.related("https://www.pinterest.com/user/board/", num=10)
+            except ValueError as e:
+                assert str(e) == "related only supports Pinterest pin URLs"
+            else:
+                raise AssertionError("Expected ValueError for non-pin related scrape")

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -1,11 +1,16 @@
 """Tests for Pinterest API URL parsing."""
 
+from unittest.mock import patch
+
 from pinterest_dl.api.api import Api
+from pinterest_dl.domain.media import PinterestMedia
 from pinterest_dl.exceptions import (
+    EmptyResponseError,
     InvalidBoardUrlError,
     InvalidPinterestUrlError,
     InvalidSearchUrlError,
 )
+from pinterest_dl.scrapers.api_scraper import ApiScraper
 
 
 class TestPinterestAPIUrlParsing:
@@ -102,3 +107,47 @@ class TestPinterestAPIUrlParsing:
         api2 = Api("https://de.pinterest.com/user/board/section/")
         assert api2.is_section is True
         assert api2.section_slug == "section"
+
+
+class TestScrapeOneFallbacks:
+    def test_scrape_one_falls_back_to_page_when_api_data_is_invalid(self):
+        with patch.object(Api, "_get_default_cookies", return_value={}):
+            scraper = ApiScraper()
+            expected = PinterestMedia(
+                id=123456789012345,
+                src="https://i.pinimg.com/originals/test.jpg",
+                alt="caption",
+                origin="https://www.pinterest.com/pin/123456789012345/",
+                resolution=(1200, 1800),
+            )
+
+            with (
+                patch.object(Api, "get_main_image", side_effect=ValueError("bad json")),
+                patch.object(ApiScraper, "_get_main_pin_from_page", return_value=expected) as page_fallback,
+            ):
+                items = scraper.scrape_one("https://www.pinterest.com/pin/123456789012345/")
+
+        assert items == [expected]
+        page_fallback.assert_called_once()
+
+    def test_scrape_one_rejects_unknown_resolution_when_min_resolution_is_requested(self):
+        html = """
+        <html>
+            <meta property="og:image" content="https://i.pinimg.com/originals/test.jpg">
+            <meta property="og:description" content="caption">
+        </html>
+        """
+
+        with patch.object(Api, "_get_default_cookies", return_value={}):
+            scraper = ApiScraper()
+
+            with (
+                patch.object(Api, "get_main_image", side_effect=EmptyResponseError("no data")),
+                patch.object(Api, "get_pin_page", return_value=html),
+            ):
+                items = scraper.scrape_one(
+                    "https://www.pinterest.com/pin/123456789012345/",
+                    min_resolution=(1000, 1000),
+                )
+
+        assert items == []


### PR DESCRIPTION
Refactors pin scraping so `scrape` now fetches the requested pin itself, while board and section URLs keep their existing behavior

Adds a dedicated `related` command/API for recommendation-style pin scraping, keeps one as a compatibility alias, fixes the scrape_one fallback/min-resolution issues, and updates docs/examples to match the new command semantics