### PR TITLE
feat!: fold one and related commands into scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Scrape images from Pinterest using the command line:
 # Scrape a board, section, or the requested pin itself
 pinterest-dl scrape <url> -o output_folder -n 50
 
-# Download exactly one pin
-pinterest-dl one <pin_url> -o output_folder
+# Download a single pin (pin URLs return the pin itself)
+pinterest-dl scrape <pin_url> -o output_folder
 
 # Download pins related to a pin
 pinterest-dl related <pin_url> -o output_folder -n 50

--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ pinterest-dl scrape <url> -o output_folder -n 50
 # Download a single pin (pin URLs return the pin itself)
 pinterest-dl scrape <pin_url> -o output_folder
 
-# Download pins related to a pin
-pinterest-dl related <pin_url> -o output_folder -n 50
+# Download a pin plus related pins (pin + 49 related)
+pinterest-dl scrape <pin_url> -o output_folder -n 50
+
+# Download only pins related to a pin (exclude the pin itself)
+pinterest-dl scrape <pin_url> --related-only -o output_folder -n 50
 
 # Download videos as MP4 (requires ffmpeg)
 pinterest-dl scrape <pin_url> --video -o output_folder
@@ -140,7 +143,7 @@ pinterest-dl login -o cookies.json
 
 **📖 [View Full CLI Documentation ->](https://github.com/sean1832/pinterest-dl/blob/main/doc/CLI.md)**
 
-Available commands: `login`, `scrape`, `related`, `one`, `search`, `download`
+Available commands: `login`, `scrape`, `search`, `download`
 
 ---
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -153,7 +153,8 @@ import json
 from pinterest_dl import PinterestDL
 
 # 1. Initialize PinterestDL with API and scrape media
-# Pin URLs return the requested pin itself. Use `.related(...)` for recommendations around a pin.
+# Pin URLs return the pin itself, then fill the rest of `num` with related pins.
+# Use `.related(...)` for recommendations only (excluding the pin itself).
 scraped_medias = PinterestDL.with_api().scrape(
     url="https://www.pinterest.com/username/board-name/",  # URL of the Pinterest page
     num=30,  # Maximum number of images to scrape

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -8,10 +8,9 @@ pinterest-dl [command] [options]
 | Command                   | Description                                                                        |
 | ------------------------- | ---------------------------------------------------------------------------------- |
 | [`login`](#1-login)       | Login to Pinterest to obtain browser cookies for scraping private boards and pins. |
-| [`scrape`](#2-scrape)     | Download the requested pin or scrape a board/section URL.                          |
-| [`related`](#3-related)   | Download pins related to a specific Pinterest pin.                                 |
-| [`search`](#4-search)     | Search for images on Pinterest using a query.                                      |
-| [`download`](#5-download) | Download images from a list of URLs provided in a JSON file.                       |
+| [`scrape`](#2-scrape)     | Download a pin (plus related pins), or scrape a board/section URL.                 |
+| [`search`](#3-search)     | Search for images on Pinterest using a query.                                      |
+| [`download`](#4-download) | Download images from a list of URLs provided in a JSON file.                       |
 
 
 ---
@@ -43,11 +42,20 @@ pinterest-dl login [options]
 ---
 
 ### 2. Scrape  
-Download the requested pin itself, or scrape a Board/Section URL.
+Download a pin (and related pins to fill `-n`), or scrape a Board/Section URL.
 
 ```bash
 # Single or multiple URLs:
 pinterest-dl scrape <url1> <url2> ...
+
+# A single pin (returns the pin itself):
+pinterest-dl scrape <pin_url>
+
+# A pin plus related pins (pin + 4 related = 5 total):
+pinterest-dl scrape <pin_url> -n 5
+
+# Only related pins, excluding the pin itself:
+pinterest-dl scrape <pin_url> -n 5 --related-only
 
 # From one or more files (one URL per line):
 pinterest-dl scrape -f urls.txt [options]
@@ -64,7 +72,8 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 | `<url>`                                     | One or more Pinterest URLs                                | -              |
 | `-o`, `--output [directory]`                | Directory to save images (stdout if omitted)              | -              |
 | `-c`, `--cookies [file]`                    | Path to cookies file (for private content)                | `cookies.json` |
-| `-n`, `--num [number]`                      | Maximum images to download (`scrape` returns 1 for pin URLs) | `100`       |
+| `-n`, `--num [number]`                      | Images to download. For a pin URL, returns the pin plus related pins to reach this count | `1` for pins, `100` for boards/sections |
+| `--related-only`                            | For a pin URL, download only related pins (exclude the pin itself); ignored for boards/sections | -        |
 | `-r`, `--resolution [WxH]`                  | Minimum image resolution (e.g. `512x512`)                 | -              |
 | `--video`                                   | Download video stream (if available)                      | -              |
 | `--skip-remux` (**NEW**)                    | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed) | -              |
@@ -82,43 +91,11 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 | `--verbose`                                 | Enable debug output                                       | -              |
 
 > [!TIP]
-> For a pin URL, `scrape` fetches the requested pin itself (one item). Use `related` when you want Pinterest recommendations around a pin.
+> For a pin URL, `scrape` returns the pin itself and fills the rest of `-n` with related pins. Pass `--related-only` to skip the pin and download recommendations alone.
 
 ---
 
-### 3. Related
-Download pins related to one or more Pinterest pins (API mode).
-
-```bash
-# Single or multiple pin URLs:
-pinterest-dl related <pin_url1> <pin_url2> ... [options]
-
-# From one or more files:
-pinterest-dl related -f urls.txt [options]
-```
-
-| Options                              | Description                                                 | Default        |
-| ------------------------------------ | ----------------------------------------------------------- | -------------- |
-| `-f`, `--file [file]`                | Path to file with URLs (one per line); use `-` for stdin    | -              |
-| `<pin_url>`                          | One or more Pinterest pin URLs                              | -              |
-| `-o`, `--output [directory]`         | Directory to save media (stdout if omitted)                 | -              |
-| `-c`, `--cookies [file]`             | Path to cookies file (for private content)                  | `cookies.json` |
-| `-n`, `--num [number]`               | Maximum related pins to download                            | `100`          |
-| `-r`, `--resolution [WxH]`           | Minimum image resolution                                    | -              |
-| `--video`                            | Download video stream (if available)                        | -              |
-| `--skip-remux` (**NEW**)             | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed)   | -              |
-| `--timeout [seconds]`                | Request timeout                                             | `10`           |
-| `--delay [seconds]`                  | Delay between requests                                      | `0.2`          |
-| `--cache [path]`                     | Save scraped URLs to JSON                                   | -              |
-| `--caption [txt/json/metadata/none]` | Caption format                                              | `none`         |
-| `--ensure-cap`                       | Require alt text on every image                             | -              |
-| `--cap-from-title`                   | Use image title as caption                                  | -              |
-| `--dump [PATH]` (**NEW**)            | Dump API requests/responses to PATH (default: `.dump`)      | -              |
-| `--verbose`                          | Enable debug output                                         | -              |
-
----
-
-### 4. Search  
+### 3. Search  
 Find and download images via a search query (API mode only), or from URL-lists in files.
 
 ```bash
@@ -156,7 +133,7 @@ cat queries.txt | pinterest-dl search -f - [options]
 
 ---
 
-### 5. Download  
+### 4. Download  
 Fetch images from a previously saved cache file.
 
 ```bash

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -10,9 +10,8 @@ pinterest-dl [command] [options]
 | [`login`](#1-login)       | Login to Pinterest to obtain browser cookies for scraping private boards and pins. |
 | [`scrape`](#2-scrape)     | Download the requested pin or scrape a board/section URL.                          |
 | [`related`](#3-related)   | Download pins related to a specific Pinterest pin.                                 |
-| [`one`](#4-one)           | Download exactly one Pinterest pin.                                                |
-| [`search`](#5-search)     | Search for images on Pinterest using a query.                                      |
-| [`download`](#6-download) | Download images from a list of URLs provided in a JSON file.                       |
+| [`search`](#4-search)     | Search for images on Pinterest using a query.                                      |
+| [`download`](#5-download) | Download images from a list of URLs provided in a JSON file.                       |
 
 
 ---
@@ -82,6 +81,9 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 | `--incognito`                               | Use incognito mode (browser clients only)                 | -              |
 | `--verbose`                                 | Enable debug output                                       | -              |
 
+> [!TIP]
+> For a pin URL, `scrape` fetches the requested pin itself (one item). Use `related` when you want Pinterest recommendations around a pin.
+
 ---
 
 ### 3. Related
@@ -116,39 +118,7 @@ pinterest-dl related -f urls.txt [options]
 
 ---
 
-### 4. One
-Download exactly one Pinterest pin.
-
-```bash
-pinterest-dl one <pin_url> [options]
-
-# Aliases:
-pinterest-dl scrape_one <pin_url> [options]
-pinterest-dl scrape-one <pin_url> [options]
-```
-
-| Options                              | Description                                               | Default        |
-| ------------------------------------ | --------------------------------------------------------- | -------------- |
-| `<pin_url>`                          | Pinterest pin URL                                         | -              |
-| `-o`, `--output [directory]`         | Directory to save media (stdout if omitted)               | -              |
-| `-c`, `--cookies [file]`             | Path to cookies file (for private content)                | `cookies.json` |
-| `-r`, `--resolution [WxH]`           | Minimum image resolution                                  | -              |
-| `--video`                            | Download video stream (if available)                      | -              |
-| `--skip-remux` (**NEW**)             | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed) | -              |
-| `--timeout [seconds]`                | Request timeout                                           | `10`           |
-| `--cache [path]`                     | Save scraped URLs to JSON                                 | -              |
-| `--caption [txt/json/metadata/none]` | Caption format                                            | `none`         |
-| `--ensure-cap`                       | Require alt text on the pin                               | -              |
-| `--cap-from-title`                   | Use image title as caption                                | -              |
-| `--dump [PATH]` (**NEW**)            | Dump API requests/responses to PATH (default: `.dump`)    | -              |
-| `--verbose`                          | Enable debug output                                       | -              |
-
-> [!TIP]
-> `scrape` and `one` both fetch the requested pin itself. Use `related` when you want Pinterest recommendations around a pin.
-
----
-
-### 5. Search  
+### 4. Search  
 Find and download images via a search query (API mode only), or from URL-lists in files.
 
 ```bash
@@ -186,7 +156,7 @@ cat queries.txt | pinterest-dl search -f - [options]
 
 ---
 
-### 6. Download  
+### 5. Download  
 Fetch images from a previously saved cache file.
 
 ```bash

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -122,7 +122,8 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("-f", "--file", action="append", help="Path to file with URLs (one per line), use '-' for stdin")
     scrape_cmd.add_argument("-o", "--output", type=str, help="Output directory")
     scrape_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private boards.")
-    scrape_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of image to scrape (default: 100)")
+    scrape_cmd.add_argument("-n", "--num", type=int, default=None, help="Number of images to download. For a pin URL, returns the pin plus related pins to reach this count (default: 1 for pins, 100 for boards/sections).")
+    scrape_cmd.add_argument("--related-only", action="store_true", help="For a pin URL, download only related pins, excluding the pin itself. Ignored for boards/sections.")
     scrape_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
     scrape_cmd.add_argument("--video", action="store_true", help="Download video streams if available")
     scrape_cmd.add_argument("--skip-remux", action="store_true", help="Skip ffmpeg remux, output raw .ts file (requires --video, no ffmpeg needed)")
@@ -139,25 +140,6 @@ def get_parser() -> argparse.ArgumentParser:
     scrape_cmd.add_argument("--backend", default="playwright", choices=["playwright", "selenium"], help="Browser backend for browser clients (default: playwright)")
     scrape_cmd.add_argument("--incognito", action="store_true", help="Incognito mode (only for browser clients)")
     scrape_cmd.add_argument("--headful", action="store_true", help="Run in headful mode with browser window (only for browser clients)")
-
-    # related command
-    related_cmd = cmd.add_parser("related", help="Download pins related to a Pinterest pin")
-    related_cmd.add_argument("urls", nargs="*", help="One or more Pinterest pin URLs")
-    related_cmd.add_argument("-f", "--file", action="append", help="Path to file with URLs (one per line), use '-' for stdin")
-    related_cmd.add_argument("-o", "--output", type=str, help="Output directory")
-    related_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private pins.")
-    related_cmd.add_argument("-n", "--num", type=int, default=100, help="Max number of related images to scrape (default: 100)")
-    related_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
-    related_cmd.add_argument("--video", action="store_true", help="Download video streams if available")
-    related_cmd.add_argument("--skip-remux", action="store_true", help="Skip ffmpeg remux, output raw .ts file (requires --video, no ffmpeg needed)")
-    related_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
-    related_cmd.add_argument("--delay", type=float, default=0.2, help="Delay between requests in seconds (default: 0.2)")
-    related_cmd.add_argument("--cache", type=str, help="path to cache URLs into json file for reuse")
-    related_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
-    related_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
-    related_cmd.add_argument("--ensure-cap", action="store_true", help="Ensure every image has alt text")
-    related_cmd.add_argument("--cap-from-title", action="store_true", help="Use the image title as the caption")
-    related_cmd.add_argument("--dump", type=str, nargs="?", const=".dump", default=None, metavar="PATH", help="Dump API requests/responses to PATH directory (default: .dump if flag used without path, disabled if not specified)")
 
     # search command
     search_cmd = cmd.add_parser("search", help="Search images from Pinterest")
@@ -286,8 +268,13 @@ def main() -> None:
 
             for url in urls:
                 url = sanitize_url(url)
+                is_pin = looks_like_pin_url(url)
+                # Pin URLs default to the pin itself; boards/sections default to a full page.
+                num = args.num if args.num is not None else (1 if is_pin else 100)
                 print(f"Scraping {url}...")
                 if args.client in ["chromium", "firefox"]:
+                    if args.related_only:
+                        print("Warning: --related-only requires the API client; ignoring.")
                     if args.backend == "selenium":
                         # Selenium backend (legacy)
                         browser_type = "chrome" if args.client == "chromium" else args.client
@@ -308,7 +295,7 @@ def main() -> None:
                                 .scrape_and_download(
                                     url,
                                     args.output,
-                                    args.num,
+                                    num,
                                     min_resolution=parse_resolution(args.resolution)
                                     if args.resolution
                                     else None,
@@ -331,7 +318,7 @@ def main() -> None:
                             imgs = scraper.with_cookies_path(args.cookies).scrape_and_download(
                                 url,
                                 args.output,
-                                args.num,
+                                num,
                                 min_resolution=parse_resolution(args.resolution)
                                 if args.resolution
                                 else None,
@@ -340,75 +327,29 @@ def main() -> None:
                             )
                         finally:
                             scraper.close()
-                    if imgs and len(imgs) != args.num:
-                        print(
-                            f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
-                        )
                 else:
                     if args.incognito or args.headful:
                         print(
                             "Warning: Incognito and headful mode is only available for browser clients."
                         )
 
-                    imgs = (
-                        PinterestDL.with_api(
-                            timeout=args.timeout,
-                            verbose=args.verbose,
-                            ensure_alt=args.ensure_cap,
-                            dump=args.dump,
+                    related_only = args.related_only and is_pin
+                    if args.related_only and not is_pin:
+                        print(
+                            f"Warning: --related-only only applies to pin URLs; scraping {url} normally."
                         )
-                        .with_cookies_path(args.cookies)
-                        .scrape_and_download(
-                            url,
-                            args.output,
-                            args.num,
-                            download_streams=args.video,
-                            skip_remux=args.skip_remux,
-                            min_resolution=parse_resolution(args.resolution)
-                            if args.resolution
-                            else (0, 0),
-                            cache_path=args.cache,
-                            caption=args.caption,
-                            delay=args.delay,
-                            caption_from_title=args.cap_from_title,
-                        )
-                    )
-                    expected_count = 1 if looks_like_pin_url(url) else args.num
-                    if imgs and len(imgs) != expected_count:
-                        if expected_count == 1:
-                            print(
-                                f"Warning: Expected 1 downloaded item from {url}, got {len(imgs)}."
-                            )
-                        else:
-                            print(
-                                f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
-                            )
 
-            print("\nDone.")
-        elif args.cmd == "related":
-            urls = combine_inputs(args.urls, args.file)
-            if not urls:
-                print("No URLs provided. Please provide at least one URL.")
-                return
-
-            if args.cookies:
-                check_and_warn_invalid_cookies(args.cookies)
-
-            for url in urls:
-                url = sanitize_url(url)
-                print(f"Scraping related pins from {url}...")
-                imgs = (
-                    PinterestDL.with_api(
+                    api = PinterestDL.with_api(
                         timeout=args.timeout,
                         verbose=args.verbose,
                         ensure_alt=args.ensure_cap,
                         dump=args.dump,
-                    )
-                    .with_cookies_path(args.cookies)
-                    .related_and_download(
+                    ).with_cookies_path(args.cookies)
+                    download = api.related_and_download if related_only else api.scrape_and_download
+                    imgs = download(
                         url,
                         args.output,
-                        args.num,
+                        num,
                         download_streams=args.video,
                         skip_remux=args.skip_remux,
                         min_resolution=parse_resolution(args.resolution)
@@ -419,10 +360,9 @@ def main() -> None:
                         delay=args.delay,
                         caption_from_title=args.cap_from_title,
                     )
-                )
-                if imgs and len(imgs) != args.num:
+                if imgs and len(imgs) != num:
                     print(
-                        f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
+                        f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {num}). Some may have been duplicates, filtered, or failed to download."
                     )
 
             print("\nDone.")

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -159,26 +159,6 @@ def get_parser() -> argparse.ArgumentParser:
     related_cmd.add_argument("--cap-from-title", action="store_true", help="Use the image title as the caption")
     related_cmd.add_argument("--dump", type=str, nargs="?", const=".dump", default=None, metavar="PATH", help="Dump API requests/responses to PATH directory (default: .dump if flag used without path, disabled if not specified)")
 
-    # one command
-    one_cmd = cmd.add_parser(
-        "one",
-        aliases=["scrape_one", "scrape-one"],
-        help="Download exactly one Pinterest pin",
-    )
-    one_cmd.add_argument("url", help="Pinterest pin URL")
-    one_cmd.add_argument("-o", "--output", type=str, help="Output directory")
-    one_cmd.add_argument("-c", "--cookies", type=str, help="Path to cookies file. Use this to scrape private pins.")
-    one_cmd.add_argument("-r", "--resolution", type=str, help="Minimum resolution to keep (e.g. 512x512).")
-    one_cmd.add_argument("--video", action="store_true", help="Download video streams if available")
-    one_cmd.add_argument("--skip-remux", action="store_true", help="Skip ffmpeg remux, output raw .ts file (requires --video, no ffmpeg needed)")
-    one_cmd.add_argument("--timeout", type=int, default=10, help="Timeout in seconds for requests (default: 10)")
-    one_cmd.add_argument("--cache", type=str, help="path to cache URLs into json file for reuse")
-    one_cmd.add_argument("--verbose", action="store_true", help="Print verbose output")
-    one_cmd.add_argument("--caption", type=str, default="none", choices=["txt", "json", "metadata", "none"], help="Caption format for downloaded images: 'txt' for alt text in separate files, 'json' for full image data in seperate file, 'metadata' embeds in image files, 'none' skips captions (default)")
-    one_cmd.add_argument("--ensure-cap", action="store_true", help="Ensure the pin has alt text")
-    one_cmd.add_argument("--cap-from-title", action="store_true", help="Use the image title as the caption")
-    one_cmd.add_argument("--dump", type=str, nargs="?", const=".dump", default=None, metavar="PATH", help="Dump API requests/responses to PATH directory (default: .dump if flag used without path, disabled if not specified)")
-
     # search command
     search_cmd = cmd.add_parser("search", help="Search images from Pinterest")
     search_cmd.add_argument("querys", nargs="*", help="Search query")
@@ -444,40 +424,6 @@ def main() -> None:
                     print(
                         f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
                     )
-
-            print("\nDone.")
-        elif args.cmd in ["one", "scrape_one", "scrape-one"]:
-            url = sanitize_url(args.url)
-
-            if args.cookies:
-                check_and_warn_invalid_cookies(args.cookies)
-
-            print(f"Scraping one pin from {url}...")
-            imgs = (
-                PinterestDL.with_api(
-                    timeout=args.timeout,
-                    verbose=args.verbose,
-                    ensure_alt=args.ensure_cap,
-                    dump=args.dump,
-                )
-                .with_cookies_path(args.cookies)
-                .scrape_one_and_download(
-                    url,
-                    args.output,
-                    download_streams=args.video,
-                    skip_remux=args.skip_remux,
-                    min_resolution=parse_resolution(args.resolution)
-                    if args.resolution
-                    else (0, 0),
-                    cache_path=args.cache,
-                    caption=args.caption,
-                    caption_from_title=args.cap_from_title,
-                )
-            )
-            if imgs and len(imgs) != 1:
-                print(
-                    f"Warning: Expected 1 downloaded item from {url}, got {len(imgs)}."
-                )
 
             print("\nDone.")
         elif args.cmd == "search":

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -257,46 +257,6 @@ class ApiScraper:
             scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
         )
 
-    def scrape_one(
-        self,
-        url: str,
-        min_resolution: Tuple[int, int] = (0, 0),
-        caption_from_title: bool = False,
-    ) -> List[PinterestMedia]:
-        """Scrape exactly one requested pin from a pin URL."""
-        api = self._create_api(url)
-
-        if not api.is_pin:
-            raise ValueError("scrape_one only supports Pinterest pin URLs")
-
-        media = self._scrape_one_pin(
-            api,
-            min_resolution,
-            caption_from_title=caption_from_title,
-        )
-        return [media] if media else []
-
-    def scrape_one_and_download(
-        self,
-        url: str,
-        output_dir: Optional[Union[str, Path]],
-        download_streams: bool = False,
-        skip_remux: bool = False,
-        min_resolution: Tuple[int, int] = (0, 0),
-        cache_path: Optional[Union[str, Path]] = None,
-        caption: Literal["txt", "json", "metadata", "none"] = "none",
-        caption_from_title: bool = False,
-    ) -> Optional[List[PinterestMedia]]:
-        """Download exactly one requested pin from a pin URL."""
-        scraped_outputs = self.scrape_one(
-            url,
-            min_resolution=min_resolution,
-            caption_from_title=caption_from_title,
-        )
-        return self._download_and_save(
-            scraped_outputs, output_dir, download_streams, skip_remux, cache_path, caption
-        )
-
     def search(
         self,
         query: str,

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -108,7 +108,8 @@ class ApiScraper:
 
         Args:
             url (str): Pinterest URL to scrape. Supports:
-                - Pin URL: scrapes the requested pin itself
+                - Pin URL: scrapes the requested pin itself, then fills the
+                  remainder of `num` with related pins when `num > 1`
                 - Board URL: scrapes pins from the board
                 - Section URL: scrapes pins from a specific board section
             num (int): Maximum number of images to scrape.
@@ -129,6 +130,17 @@ class ApiScraper:
                 caption_from_title=caption_from_title,
             )
             medias = [media] if media else []
+            # When more than the pin itself is requested, fill the remainder with related pins.
+            if num > 1:
+                related = self._scrape_pins(
+                    api,
+                    num - len(medias),
+                    min_resolution,
+                    delay,
+                    BookmarkManager(3),
+                    caption_from_title=caption_from_title,
+                )
+                medias.extend(related)
         elif api.is_section:
             # Section URL detected - scrape only this section
             medias = self._scrape_section(
@@ -201,7 +213,8 @@ class ApiScraper:
 
         Args:
             url (str): Pinterest URL to scrape. Supports:
-                - Pin URL: scrapes the requested pin itself
+                - Pin URL: scrapes the requested pin itself, then fills the
+                  remainder of `num` with related pins when `num > 1`
                 - Board URL: scrapes pins from the board
                 - Section URL: scrapes pins from a specific board section
             output_dir (Optional[Union[str, Path]]): Directory to store downloaded images. 'None' print to console.

--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -139,6 +139,7 @@ class ApiScraper:
                     delay,
                     BookmarkManager(3),
                     caption_from_title=caption_from_title,
+                    progress_offset=len(medias),
                 )
                 medias.extend(related)
         elif api.is_section:
@@ -422,12 +423,24 @@ class ApiScraper:
         delay: float,
         bookmarks: BookmarkManager,
         caption_from_title: bool = False,
+        progress_offset: int = 0,
     ) -> List[PinterestMedia]:
-        """Scrape related pins from a specific Pinterest pin URL."""
+        """Scrape related pins from a specific Pinterest pin URL.
+
+        progress_offset seeds the progress bar with items already collected by
+        the caller (e.g. the pin itself when scrape() fills with related pins),
+        so the bar reflects the full requested count rather than just the
+        related pins. It only affects display, not how many pins are scraped.
+        """
         images: List[PinterestMedia] = []
         remains = num
 
-        with tqdm(total=num, desc="Scraping Pins", disable=self.verbose) as pbar:
+        with tqdm(
+            total=num + progress_offset,
+            initial=progress_offset,
+            desc="Scraping Pins",
+            disable=self.verbose,
+        ) as pbar:
             while remains > 0:
                 batch_size = min(50, remains)
                 try:
@@ -577,6 +590,10 @@ class ApiScraper:
         caption_from_title: bool = False,
     ) -> PinterestMedia:
         """Parse pin metadata from the public pin page HTML."""
+        pin_id = api.pin_id
+        if pin_id is None:
+            raise ValueError(f"Cannot parse pin page without a pin id (url={api.url!r})")
+
         html = api.get_pin_page()
         meta = self._extract_meta_tags(html)
 
@@ -610,7 +627,7 @@ class ApiScraper:
         video_stream = self._extract_video_stream_from_meta(meta) or self._extract_video_stream_from_html(html)
 
         return PinterestMedia(
-            id=int(api.pin_id),
+            id=int(pin_id),
             src=src,
             alt=alt,
             origin=api.url,

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -130,8 +130,8 @@ class TestPinterestAPIUrlParsing:
         assert api2.section_slug == "section"
 
 
-class TestScrapeOneFallbacks:
-    def test_scrape_one_falls_back_to_page_when_api_data_is_invalid(self):
+class TestScrapePinFallbacks:
+    def test_scrape_falls_back_to_page_when_api_data_is_invalid(self):
         with patch.object(Api, "_get_default_cookies", return_value={}):
             scraper = ApiScraper()
             expected = PinterestMedia(
@@ -146,12 +146,12 @@ class TestScrapeOneFallbacks:
                 patch.object(Api, "get_main_image", side_effect=ValueError("bad json")),
                 patch.object(ApiScraper, "_get_main_pin_from_page", return_value=expected) as page_fallback,
             ):
-                items = scraper.scrape_one("https://www.pinterest.com/pin/123456789012345/")
+                items = scraper.scrape("https://www.pinterest.com/pin/123456789012345/", num=1)
 
         assert items == [expected]
         page_fallback.assert_called_once()
 
-    def test_scrape_one_rejects_unknown_resolution_when_min_resolution_is_requested(self):
+    def test_scrape_rejects_unknown_resolution_when_min_resolution_is_requested(self):
         html = """
         <html>
             <meta property="og:image" content="https://i.pinimg.com/originals/test.jpg">
@@ -166,8 +166,9 @@ class TestScrapeOneFallbacks:
                 patch.object(Api, "get_main_image", side_effect=EmptyResponseError("no data")),
                 patch.object(Api, "get_pin_page", return_value=html),
             ):
-                items = scraper.scrape_one(
+                items = scraper.scrape(
                     "https://www.pinterest.com/pin/123456789012345/",
+                    num=1,
                     min_resolution=(1000, 1000),
                 )
 

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -176,7 +176,7 @@ class TestScrapePinFallbacks:
 
 
 class TestApiScraperRouting:
-    def test_scrape_fetches_requested_pin_for_pin_urls(self):
+    def test_scrape_returns_only_the_pin_when_num_is_one(self):
         fake_api = SimpleNamespace(is_pin=True, is_section=False)
         expected = PinterestMedia(
             id=123,
@@ -189,9 +189,10 @@ class TestApiScraperRouting:
         with (
             patch("pinterest_dl.scrapers.api_scraper.Api", return_value=fake_api),
             patch.object(ApiScraper, "_scrape_one_pin", return_value=expected) as scrape_one_pin,
+            patch.object(ApiScraper, "_scrape_pins") as scrape_pins,
         ):
             scraper = ApiScraper()
-            items = scraper.scrape("https://www.pinterest.com/pin/123/", num=50)
+            items = scraper.scrape("https://www.pinterest.com/pin/123/", num=1)
 
         assert items == [expected]
         scrape_one_pin.assert_called_once_with(
@@ -199,6 +200,46 @@ class TestApiScraperRouting:
             (0, 0),
             caption_from_title=False,
         )
+        scrape_pins.assert_not_called()
+
+    def test_scrape_fills_with_related_when_num_exceeds_one(self):
+        fake_api = SimpleNamespace(is_pin=True, is_section=False)
+        pin = PinterestMedia(
+            id=123,
+            src="https://i.pinimg.com/originals/pin.jpg",
+            alt="caption",
+            origin="https://www.pinterest.com/pin/123/",
+            resolution=(1200, 1800),
+        )
+        related = [
+            PinterestMedia(
+                id=456,
+                src="https://i.pinimg.com/originals/related-1.jpg",
+                alt="related 1",
+                origin="https://www.pinterest.com/pin/456/",
+                resolution=(1200, 1800),
+            ),
+            PinterestMedia(
+                id=789,
+                src="https://i.pinimg.com/originals/related-2.jpg",
+                alt="related 2",
+                origin="https://www.pinterest.com/pin/789/",
+                resolution=(1200, 1800),
+            ),
+        ]
+
+        with (
+            patch("pinterest_dl.scrapers.api_scraper.Api", return_value=fake_api),
+            patch.object(ApiScraper, "_scrape_one_pin", return_value=pin),
+            patch.object(ApiScraper, "_scrape_pins", return_value=related) as scrape_pins,
+        ):
+            scraper = ApiScraper()
+            items = scraper.scrape("https://www.pinterest.com/pin/123/", num=3)
+
+        assert items == [pin, *related]
+        scrape_pins.assert_called_once()
+        # The pin counts as one item, so only the remaining (num - 1) are requested as related.
+        assert scrape_pins.call_args.args[1] == 2
 
     def test_scrape_uses_board_flow_for_board_urls(self):
         fake_api = SimpleNamespace(is_pin=False, is_section=False)


### PR DESCRIPTION
## Why

`scrape <pin_url>` silently ignored `-n`, always returning one image. The `one` and `related` commands existed to paper over this - `one` was identical to `scrape` on a pin URL, and `related` was a separate command for what is naturally just "scrape this pin and get more." This gives `-n` a consistent meaning everywhere: total items you want, regardless of source.

## What changed

- `pinterest_dl/scrapers/api_scraper.py`: `scrape()` now fills pin requests with related pins when `num > 1`; removes `scrape_one` / `scrape_one_and_download`; `_scrape_pins` gains `progress_offset` so the tqdm bar reflects the full requested count rather than just the related portion; `_get_main_pin_from_page` narrows `api.pin_id` from `str | None` before `int()` to fix a pyright warning
- `pinterest_dl/cli.py`: removes `one`, `scrape_one`, `scrape-one`, and `related` subcommands; adds `--related-only` flag; `-n` default resolved per-URL at dispatch (1 for pins, 100 for boards/sections)
- `tests/test_pinterest_api.py`: adds `test_scrape_fills_with_related_when_num_exceeds_one`; migrates fallback and routing tests off removed `scrape_one`
- `doc/CLI.md`, `README.md`, `doc/API.md`: updated to reflect new changes

## Notes

`-n` default can't be a literal global `1`,  that would silently regress board scraping. It's resolved per-URL inside the dispatch loop. The library `related()` / `related_and_download()` methods are kept on `ApiScraper` for programmatic use; only the CLI command is removed. `--related-only` warns and ignores for browser clients (Playwright/Selenium don't expose the related-pins API endpoint).

**Breaking changes:**
- `scrape <pin> -n N` (N > 1) now returns pin + related instead of just the pin
- CLI commands `one`, `scrape_one`, `scrape-one`, `related` removed
- Library `scrape_one()` and `scrape_one_and_download()` removed
