### PR TITLE
fix(hls): support byte-range fMP4 streams and fix Retry import

### DIFF
--- a/pinterest_dl/download/http_client.py
+++ b/pinterest_dl/download/http_client.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from typing import Iterable, List, Union
+from typing import List, Union
 
 import requests
 import requests.adapters
@@ -95,31 +95,46 @@ class HttpClient:
             base_uri = playlist.base_uri or media_url.rsplit("/", 1)[0] + "/"
 
         # enumerate segments
+        init = self.hls_processor.get_init_section(playlist, base_uri)
         segments = self.hls_processor.enumerate_segments(playlist, base_uri)
         with tempfile.TemporaryDirectory() as td:
             temp_dir = Path(td)
             segment_paths: List[Path] = []
-            iterator: Iterable = enumerate(segments)
-            for index, segment in iterator:
-                raw = self.hls_processor.download_segment(segment.uri)
+
+            # download init section if present
+            if init is not None:
+                init_bytes = self.hls_processor.download_segment(
+                    init.uri, init.byte_offset, init.byte_length
+                )
+                init_path = temp_dir / "init.mp4"
+                self.hls_processor.write_segment_file(init_path, init_bytes)
+                segment_paths.append(init_path)
+
+            for index, segment in enumerate(segments):
+                raw = self.hls_processor.download_segment(
+                    segment.uri, segment.byte_offset, segment.byte_length
+                )
                 data = self.hls_processor.decrypt(segment, raw)
                 segment_path = temp_dir / f"segment_{index:05d}.ts"
                 self.hls_processor.write_segment_file(segment_path, data)
                 segment_paths.append(segment_path)
 
+            # fMP4 (has init) -> .mp4. Plain TS (no init) -> .ts
+            suffix = ".mp4" if init is not None else ".ts"
+
             if skip_remux:
-                # Binary concat to .ts file (no ffmpeg)
-                output_ts = output_path.with_suffix(".ts")
-                self.hls_processor.concat_to_ts(segment_paths, output_ts)
-                return output_ts
-            else:
-                # Remux to .mp4 using ffmpeg, fallback to re-encode if remux fails
-                output_mp4 = output_path.with_suffix(".mp4")
-                concat_list = temp_dir / "concat_list.txt"
-                self.hls_processor.build_concat_list(segment_paths, concat_list)
-                try:
-                    self.hls_processor.remux_to_mp4(concat_list, output_mp4)
-                except Exception:
-                    logger.warning("Remux failed, re-encoding video (this may take longer)...")
-                    self.hls_processor.reencode_to_mp4(concat_list, output_mp4)
-                return output_mp4
+                final = output_path.with_suffix(suffix)
+                self.hls_processor.concat_to_ts(
+                    segment_paths, final
+                )  # binary concat straight to output
+                return final
+
+            combined = temp_dir / f"combined{suffix}"
+            self.hls_processor.concat_to_ts(segment_paths, combined)
+            output_mp4 = output_path.with_suffix(".mp4")
+            try:
+                self.hls_processor.remux_to_mp4(combined, output_mp4)
+            except Exception:
+                logger.warning("Remux failed, re-encoding video (this may take longer)...")
+                self.hls_processor.reencode_to_mp4(combined, output_mp4)
+            return output_mp4

--- a/pinterest_dl/download/http_client.py
+++ b/pinterest_dl/download/http_client.py
@@ -4,6 +4,7 @@ from typing import List, Union
 
 import requests
 import requests.adapters
+from urllib3.util.retry import Retry
 
 from pinterest_dl.common.logging import get_logger
 from pinterest_dl.download.video.hls_processor import HlsProcessor
@@ -29,7 +30,7 @@ class HttpClient:
         """
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": user_agent})
-        retries = requests.adapters.Retry(
+        retries = Retry(
             total=max_retries,
             backoff_factor=backoff_factor,
             status_forcelist=[429, 500, 502, 503, 504],

--- a/pinterest_dl/download/video/hls_processor.py
+++ b/pinterest_dl/download/video/hls_processor.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from urllib.parse import urljoin
 
 import m3u8
@@ -73,6 +73,32 @@ class HlsProcessor:
         )
         return urljoin(base_uri, best.uri)
 
+    def get_init_section(self, playlist: m3u8.M3U8, base_uri: str) -> Optional[SegmentInfo]:
+        """Get the initialization section data if present.
+
+        Args:
+            playlist (m3u8.M3U8): The HLS playlist.
+            base_uri (str): The base URI for resolving segment URLs.
+        Returns:
+            Optional[SegmentInfo]: The initialization section information, or None if not present.
+        """
+        if not playlist.segment_map:
+            return None
+        init = playlist.segment_map[0]
+        byte_offset = byte_length = None  # if byterange is not present, these will remain None
+        if init.byterange:
+            byte_offset, byte_length = self._parse_byterange(init.byterange, 0)
+        return SegmentInfo(
+            index=-1,
+            uri=urljoin(base_uri, init.uri),
+            method=None,
+            key_uri=None,
+            iv=None,
+            media_sequence=playlist.media_sequence or 0,
+            byte_offset=byte_offset,
+            byte_length=byte_length,
+        )
+
     def enumerate_segments(self, playlist: m3u8.M3U8, base_uri: str) -> List[SegmentInfo]:
         """Enumerate segments in the playlist.
 
@@ -91,12 +117,15 @@ class HlsProcessor:
         if not playlist.segments:
             raise HlsDownloadError("Playlist has no segments")
         media_sequence = playlist.media_sequence or 0
+        prev_end = 0
         infos: List[SegmentInfo] = []
         for idx, segment in enumerate(playlist.segments):
             seg_url = urljoin(base_uri, segment.uri)
             method = None
             key_uri = None
             iv_bytes: Optional[bytes] = None
+            byte_length: Optional[int] = None
+            byte_offset: Optional[int] = None
             if segment.key:
                 key_info = segment.key
                 method = key_info.method
@@ -110,6 +139,9 @@ class HlsProcessor:
                     iv_bytes = bytes.fromhex(hexstr)
                 else:
                     iv_bytes = self._compute_default_iv(media_sequence, idx)
+            if segment.byterange:
+                byte_offset, byte_length = self._parse_byterange(segment.byterange, prev_end)
+                prev_end = byte_offset + byte_length
             infos.append(
                 SegmentInfo(
                     index=idx,
@@ -118,27 +150,60 @@ class HlsProcessor:
                     key_uri=key_uri,
                     iv=iv_bytes,
                     media_sequence=media_sequence,
+                    byte_offset=byte_offset,
+                    byte_length=byte_length,
                 )
             )
         return infos
 
-    def download_segment(self, url: str) -> bytes:
-        """Download a segment.
+    @staticmethod
+    def _parse_byterange(spec: str, offset: int) -> Tuple[int, int]:
+        """
+        Parse an EXT-X-BYTERANGE 'length[@offset]' value into (offset, length).
+
+        Args:
+            spec (str): The byterange specification string (e.g., "5000@10000" or "5000").
+            offset (int): The starting byte offset, used for absolute ranges.
+
+        Returns:
+            Tuple[int, int]: A tuple of (offset, length) where offset is the starting byte and length is the number of bytes.
+        """
+        spec = spec.strip()
+        if "@" in spec:
+            length_str, offset_str = spec.split("@", 1)
+            return int(offset_str), int(length_str)
+
+        return offset, int(spec)
+
+    def download_segment(
+        self, url: str, byte_offset: Optional[int] = None, byte_length: Optional[int] = None
+    ) -> bytes:
+        """Download a segment with optional byte range.
 
         Args:
             url (str): The URL of the segment.
-
-        Raises:
-            HlsDownloadError: If the segment cannot be downloaded.
+            byte_offset (Optional[int]): The starting byte offset for the segment, if using byte range.
+            byte_length (Optional[int]): The length in bytes to download, if using byte range.
 
         Returns:
-            bytes: The content of the downloaded segment.
+            bytes: The downloaded segment data.
         """
+        headers = None
+        # If both byte_offset and byte_length are provided, set the Range header
+        if byte_offset is not None and byte_length is not None:
+            headers = {"Range": f"bytes={byte_offset}-{byte_offset + byte_length - 1}"}
         last_exc = None
         for attempt in range(1, self.max_retries + 1):
             try:
-                resp = self.session.get(url, timeout=self.timeout)
+                resp = self.session.get(url, timeout=self.timeout, headers=headers)
+                if resp.status_code == 206:
+                    # Partial Content: server honored the Range request
+                    return resp.content
                 if resp.status_code == 200:
+                    # Server ignored Range and sent the whole file.
+                    # Slice so we never concatenate full copies
+                    if byte_offset is not None and byte_length is not None:
+                        return resp.content[byte_offset : byte_offset + byte_length]
                     return resp.content
                 last_exc = HlsDownloadError(f"HTTP {resp.status_code} for segment: {url}")
             except requests.RequestException as e:
@@ -195,18 +260,6 @@ class HlsProcessor:
         path.write_bytes(data)
 
     @staticmethod
-    def build_concat_list(segment_paths: List[Path], output_list: Path) -> None:
-        """Build a concat list file for ffmpeg.
-
-        Args:
-            segment_paths (List[Path]): The paths to the segment files.
-            output_list (Path): The path to the output concat list file.
-        """
-        with output_list.open("w", encoding="utf-8") as f:
-            for p in segment_paths:
-                f.write(f"file '{p.as_posix()}'\n")
-
-    @staticmethod
     def concat_to_ts(segment_paths: List[Path], output_ts: Path) -> None:
         """Binary concatenate .ts segments into a single .ts file without ffmpeg.
 
@@ -218,11 +271,11 @@ class HlsProcessor:
             for seg_path in segment_paths:
                 out.write(seg_path.read_bytes())
 
-    def remux_to_mp4(self, concat_list: Path, output_mp4: Path) -> None:
+    def remux_to_mp4(self, input_file: Path, output_mp4: Path) -> None:
         """Concatenate segments and remux to MP4 using ffmpeg (stream copy, no re-encode).
 
         Args:
-            concat_list (Path): Path to the file containing the list of segments.
+            input_file (Path): Path to the concatenated input .ts file.
             output_mp4 (Path): Path to the output MP4 file.
 
         Raises:
@@ -234,26 +287,23 @@ class HlsProcessor:
                 "-y",
                 "-loglevel",
                 "info",
-                "-f",
-                "concat",
-                "-safe",
-                "0",
                 "-i",
-                str(concat_list),
+                input_file.absolute().as_posix(),
                 "-c",
                 "copy",
-                str(output_mp4),
+                output_mp4.absolute().as_posix(),
             ],
             "remux to mp4",
         )
 
     # TODO: Expose reencode_to_mp4 via CLI flag (e.g. --reencode) for guaranteed mp4 output
-    def reencode_to_mp4(self, concat_list: Path, output_mp4: Path) -> None:
+    def reencode_to_mp4(self, input_file: Path, output_mp4: Path, crf: int = 23) -> None:
         """Concatenate segments and re-encode to MP4 using ffmpeg (slower but more compatible).
 
         Args:
-            concat_list (Path): Path to the file containing the list of segments.
+            input_file (Path): Path to the concatenated input .ts file.
             output_mp4 (Path): Path to the output MP4 file.
+            crf (int): The CRF value for x264 encoding (lower is better quality, default 23).
 
         Raises:
             HlsDownloadError: If ffmpeg re-encode fails.
@@ -264,23 +314,19 @@ class HlsProcessor:
                 "-y",
                 "-loglevel",
                 "info",
-                "-f",
-                "concat",
-                "-safe",
-                "0",
                 "-i",
-                str(concat_list),
+                input_file.absolute().as_posix(),
                 "-c:v",
                 "libx264",
                 "-preset",
                 "medium",
                 "-crf",
-                "23",
+                str(crf),
                 "-c:a",
                 "aac",
                 "-b:a",
                 "128k",
-                str(output_mp4),
+                output_mp4.absolute().as_posix(),
             ],
             "re-encode to mp4",
         )

--- a/pinterest_dl/download/video/segment_info.py
+++ b/pinterest_dl/download/video/segment_info.py
@@ -10,3 +10,5 @@ class SegmentInfo:
     key_uri: Optional[str]
     iv: Optional[bytes]  # explicit IV or None
     media_sequence: int
+    byte_offset: Optional[int] = None
+    byte_length: Optional[int] = None

--- a/tests/test_hls_processor.py
+++ b/tests/test_hls_processor.py
@@ -107,6 +107,88 @@ class TestHlsProcessor:
         with pytest.raises(HlsDownloadError, match="Unsupported encryption method"):
             processor.enumerate_segments(mock_playlist, "http://example.com/")
 
+    def test_parse_byterange(self, processor):
+        """Parse 'length@offset' and bare 'length' (implicit offset) forms."""
+        assert processor._parse_byterange("500@1000", 0) == (1000, 500)
+        # When '@offset' is omitted, the range continues from the previous end.
+        assert processor._parse_byterange("500", 1500) == (1500, 500)
+
+    def test_enumerate_segments_byterange(self, processor):
+        """Byte-range segments sharing one file keep distinct (offset, length).
+
+        Regression: the ranges used to be dropped, so every segment resolved to
+        the same URL and the whole file was downloaded once per segment, yielding
+        a video repeated N times.
+        """
+        mock_playlist = MagicMock()
+        mock_playlist.media_sequence = 0
+
+        seg1 = MagicMock()
+        seg1.uri = "video.cmfv"
+        seg1.key = None
+        seg1.byterange = "100@0"
+
+        seg2 = MagicMock()
+        seg2.uri = "video.cmfv"
+        seg2.key = None
+        seg2.byterange = "200@100"
+
+        mock_playlist.segments = [seg1, seg2]
+        segments = processor.enumerate_segments(mock_playlist, "http://example.com/")
+
+        assert segments[0].uri == segments[1].uri == "http://example.com/video.cmfv"
+        assert (segments[0].byte_offset, segments[0].byte_length) == (0, 100)
+        assert (segments[1].byte_offset, segments[1].byte_length) == (100, 200)
+
+    def test_get_init_section(self, processor):
+        """EXT-X-MAP init section is resolved with its byte range."""
+        mock_playlist = MagicMock()
+        mock_playlist.media_sequence = 0
+        init = MagicMock()
+        init.uri = "video.cmfv"
+        init.byterange = "899@0"
+        mock_playlist.segment_map = [init]
+
+        result = processor.get_init_section(mock_playlist, "http://example.com/")
+
+        assert result is not None
+        assert result.uri == "http://example.com/video.cmfv"
+        assert (result.byte_offset, result.byte_length) == (0, 899)
+
+    def test_get_init_section_absent(self, processor):
+        """No EXT-X-MAP -> no init section (plain .ts streams)."""
+        mock_playlist = MagicMock()
+        mock_playlist.segment_map = []
+        assert processor.get_init_section(mock_playlist, "http://example.com/") is None
+
+    def test_download_segment_byterange_uses_range_header(self, processor, mock_session):
+        """Range request sends a Range header and accepts HTTP 206."""
+        resp = MagicMock()
+        resp.status_code = 206
+        resp.content = b"partial-bytes"
+        mock_session.get.return_value = resp
+
+        data = processor.download_segment(
+            "http://example.com/v.cmfv", byte_offset=100, byte_length=50
+        )
+
+        assert data == b"partial-bytes"
+        _, kwargs = mock_session.get.call_args
+        assert kwargs["headers"] == {"Range": "bytes=100-149"}
+
+    def test_download_segment_200_slices_when_range_ignored(self, processor, mock_session):
+        """If the server ignores Range and returns 200, slice locally."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"0123456789"
+        mock_session.get.return_value = resp
+
+        data = processor.download_segment(
+            "http://example.com/v.cmfv", byte_offset=2, byte_length=4
+        )
+
+        assert data == b"2345"
+
     def test_decrypt_aes128(self, processor):
         """Test AES-128 decryption logic."""
         # Setup mock key cache
@@ -138,21 +220,22 @@ class TestHlsProcessor:
 
     @patch("subprocess.run")
     def test_remux_to_mp4_success(self, mock_run, processor):
-        """Test successful remux command."""
+        """Test successful remux command (single input file, stream copy)."""
         mock_run.return_value.returncode = 0
-        
-        concat_list = Path("list.txt")
+
+        input_file = Path("combined.ts")
         output_mp4 = Path("output.mp4")
-        
-        processor.remux_to_mp4(concat_list, output_mp4)
-        
+
+        processor.remux_to_mp4(input_file, output_mp4)
+
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
         assert args[0] == "ffmpeg"
+        assert "-i" in args
         assert "-c" in args
-        assert "copy" in args # verify stream copy is used
-        assert str(concat_list) in args
-        assert str(output_mp4) in args
+        assert "copy" in args  # verify stream copy is used
+        assert input_file.absolute().as_posix() in args
+        assert output_mp4.absolute().as_posix() in args
 
     @patch("subprocess.run")
     def test_reencode_to_mp4_failure_handling(self, mock_run, processor):

--- a/tests/test_http_client_video.py
+++ b/tests/test_http_client_video.py
@@ -24,31 +24,34 @@ class TestHttpClientVideo:
         mock_playlist.is_variant = False # Simulate leaf playlist
         mock_playlist.base_uri = "http://example.com/"
         mock_processor.fetch_playlist.return_value = mock_playlist
-        
+
+        # Plain .ts stream: no EXT-X-MAP init section
+        mock_processor.get_init_section.return_value = None
+
         # 2. Segments Setup
         seg1 = SegmentInfo(0, "seg1.ts", None, None, None, 0)
         seg2 = SegmentInfo(1, "seg2.ts", None, None, None, 1)
         mock_processor.enumerate_segments.return_value = [seg1, seg2]
-        
+
         # 3. Download/Decrypt Setup
         mock_processor.download_segment.return_value = b"encrypted"
         mock_processor.decrypt.return_value = b"decrypted"
-        
+
         client.download_streams(url, output_mp4, skip_remux=False)
-        
+
         # Verifications
         mock_processor.fetch_playlist.assert_called_with(url)
         mock_processor.enumerate_segments.assert_called()
-        
+
         # Should download and decrypt every segment
         assert mock_processor.download_segment.call_count == 2
         assert mock_processor.decrypt.call_count == 2
         assert mock_processor.write_segment_file.call_count == 2
-        
-        # Should build concat list
-        mock_processor.build_concat_list.assert_called_once()
-        
-        # Should call remux
+
+        # Should binary-concat the segments into one file
+        mock_processor.concat_to_ts.assert_called_once()
+
+        # Should remux (stream copy), not re-encode
         mock_processor.remux_to_mp4.assert_called_once()
         mock_processor.reencode_to_mp4.assert_not_called()
 
@@ -60,8 +63,9 @@ class TestHttpClientVideo:
         mock_playlist = MagicMock()
         mock_playlist.is_variant = False
         mock_processor.fetch_playlist.return_value = mock_playlist
+        mock_processor.get_init_section.return_value = None
         mock_processor.enumerate_segments.return_value = [] # Empty just to skip loop
-        
+
         # Simulate remux failure
         mock_processor.remux_to_mp4.side_effect = Exception("Remux failed")
         
@@ -77,14 +81,48 @@ class TestHttpClientVideo:
         mock_playlist = MagicMock()
         mock_playlist.is_variant = False
         mock_processor.fetch_playlist.return_value = mock_playlist
+        mock_processor.get_init_section.return_value = None
         mock_processor.enumerate_segments.return_value = []
-        
+
         result = client.download_streams("url", output_path, skip_remux=True)
-        
-        # Expectation: output path extension changed to .ts
+
+        # Expectation: plain .ts stream keeps the .ts extension
         expected_output = output_path.with_suffix(".ts")
         assert result == expected_output
-        
+
         # Should call concat_to_ts, NOT remux/reencode
         mock_processor.concat_to_ts.assert_called_once()
         mock_processor.remux_to_mp4.assert_not_called()
+
+    def test_download_streams_fmp4_with_init(self, client, mock_processor, tmp_path):
+        """Fragmented-MP4 byte-range stream: init fetched first, output is .mp4."""
+        output_path = tmp_path / "video"
+
+        mock_playlist = MagicMock()
+        mock_playlist.is_variant = False
+        mock_playlist.base_uri = "http://example.com/"
+        mock_processor.fetch_playlist.return_value = mock_playlist
+
+        # EXT-X-MAP init section (ftyp+moov) and two byte-range fragments of one file
+        init = SegmentInfo(-1, "http://example.com/v.cmfv", None, None, None, 0, 0, 899)
+        mock_processor.get_init_section.return_value = init
+        seg1 = SegmentInfo(0, "http://example.com/v.cmfv", None, None, None, 0, 899, 500)
+        seg2 = SegmentInfo(1, "http://example.com/v.cmfv", None, None, None, 0, 1399, 600)
+        mock_processor.enumerate_segments.return_value = [seg1, seg2]
+        mock_processor.download_segment.return_value = b"x"
+        mock_processor.decrypt.side_effect = lambda segment, data: data
+
+        result = client.download_streams(
+            "http://example.com/master.m3u8", output_path, skip_remux=False
+        )
+
+        # init + both fragments fetched, each with its own byte range
+        assert mock_processor.download_segment.call_count == 3
+        mock_processor.download_segment.assert_any_call("http://example.com/v.cmfv", 0, 899)
+        mock_processor.download_segment.assert_any_call("http://example.com/v.cmfv", 899, 500)
+
+        # fMP4 -> .mp4 output, assembled by binary concat then remux (stream copy)
+        assert result.suffix == ".mp4"
+        mock_processor.concat_to_ts.assert_called_once()
+        mock_processor.remux_to_mp4.assert_called_once()
+        mock_processor.reencode_to_mp4.assert_not_called()


### PR DESCRIPTION
## Why

Fixes #77. Pinterest videos served as fragmented MP4 (fMP4) over HLS use `EXT-X-MAP` init sections and `EXT-X-BYTERANGE` segment directives that the downloader previously ignored entirely. The symptom reported in the issue was output files with the video content repeated N times (one copy per byte-range segment, because each segment downloaded the entire backing file). This PR teaches the HLS pipeline to honor byte-range coordinates and init sections so each segment fetches only its designated slice.

A secondary fix (9029288) corrects a `requests.adapters.Retry` import that broke on some `urllib3` versions by importing `Retry` directly from `urllib3.util.retry`.

## What changed

- 9029288 - imports `Retry` directly from `urllib3.util.retry` instead of `requests.adapters.Retry` to fix compatibility with newer `urllib3` versions.
- 2318e3d - adds `EXT-X-BYTERANGE` and `EXT-X-MAP` support to the HLS pipeline: `SegmentInfo` gains `byte_offset`/`byte_length` fields; `get_init_section()` extracts the fMP4 init box; `download_segment()` sends a `Range` header and handles HTTP 206; `http_client` downloads the init section first, binary-concatenates all pieces, then remuxes from one file; output uses `.mp4` for fMP4 streams and `.ts` for plain TS.

## Notes

The ffmpeg concat-list approach was dropped in favor of a single binary-concatenated file (`combined.ts` / `combined.mp4`) because ffmpeg's `-f concat` protocol is not needed once segments are already merged, and it was the source of Windows path-escaping issues that caused intermittent remux failures. Plain `-i <file>` is simpler and more portable.

When a server ignores the `Range` header and returns HTTP 200, `download_segment` slices the response locally (`content[offset:offset+length]`) so no extra bytes are written to disk.