### PR TITLE
Fix non-Latin board and section URL parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test_output/
 *.json
 
 test.py
+tmp/

--- a/pinterest_dl/api/api.py
+++ b/pinterest_dl/api/api.py
@@ -1,6 +1,6 @@
 import re
 from typing import List, Optional, Tuple
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 import requests
 
@@ -16,7 +16,6 @@ from pinterest_dl.exceptions import (
     InvalidSearchUrlError,
     InvalidSectionUrlError,
 )
-from urllib.parse import urlsplit, urlunsplit
 
 logger = get_logger(__name__)
 
@@ -575,10 +574,10 @@ class Api:
         if len(segments) != 2:
             raise InvalidBoardUrlError(f"Invalid Pinterest board URL: {url}")
 
-        username, boardname = segments
-        if not re.fullmatch(r"[A-Za-z0-9_-]+", username) or not re.fullmatch(
-            r"[A-Za-z0-9_-]+", boardname
-        ):
+        # Board slugs can be percent-encoded Unicode (e.g. Japanese board names).
+        # Decode them so the slug passed to the API matches what Pinterest expects.
+        username, boardname = (unquote(segment) for segment in segments)
+        if not re.fullmatch(r"[\w-]+", username) or not re.fullmatch(r"[\w-]+", boardname):
             raise InvalidBoardUrlError(f"Invalid Pinterest board URL: {url}")
 
         return username, boardname
@@ -601,8 +600,9 @@ class Api:
         if len(segments) != 3:
             raise InvalidSectionUrlError(f"Invalid Pinterest section URL: {url}")
 
-        username, boardname, section_slug = segments
-        valid_segment = re.compile(r"[A-Za-z0-9_-]+$")
+        # Slugs can be percent-encoded Unicode (e.g. Japanese names); decode before use.
+        username, boardname, section_slug = (unquote(segment) for segment in segments)
+        valid_segment = re.compile(r"[\w-]+")
         if not (
             valid_segment.fullmatch(username)
             and valid_segment.fullmatch(boardname)

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -54,6 +54,24 @@ class TestPinterestAPIUrlParsing:
         assert api.username == "DRAMrefresh"
         assert api.boardname == "what-the-dog-doin"
 
+    # Synthetic non-Latin board slug (katakana for "test"); percent-encoded in
+    # URLs as "%E3%83%86%E3%82%B9%E3%83%88-2". Regression cover for issue #72.
+    UNICODE_BOARD_SLUG = "テスト-2"
+
+    def test_parse_board_url_with_percent_encoded_unicode(self):
+        """Percent-encoded Unicode board slugs should decode (issue #72)."""
+        with patch.object(Api, "_get_default_cookies", return_value={}):
+            api = Api("https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/")
+        assert api.username == "testuser"
+        assert api.boardname == self.UNICODE_BOARD_SLUG
+
+    def test_parse_board_url_with_raw_unicode(self):
+        """Non-encoded Unicode board slugs should also parse."""
+        with patch.object(Api, "_get_default_cookies", return_value={}):
+            api = Api(f"https://www.pinterest.com/testuser/{self.UNICODE_BOARD_SLUG}/")
+        assert api.username == "testuser"
+        assert api.boardname == self.UNICODE_BOARD_SLUG
+
     def test_parse_search_query_url(self):
         """Test parsing search query from URL."""
         api = Api("https://www.pinterest.com/search/pins/?q=nature&rs=typed")
@@ -109,6 +127,17 @@ class TestPinterestAPIUrlParsing:
         assert api.username == "testuser"
         assert api.boardname == "my-board"
         assert api.section_slug == "my-section"
+        assert api.is_section is True
+
+    def test_parse_section_url_with_percent_encoded_unicode(self):
+        """Percent-encoded Unicode board/section slugs should decode (issue #72)."""
+        with patch.object(Api, "_get_default_cookies", return_value={}):
+            api = Api(
+                "https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/live/"
+            )
+        assert api.username == "testuser"
+        assert api.boardname == self.UNICODE_BOARD_SLUG
+        assert api.section_slug == "live"
         assert api.is_section is True
 
     def test_board_url_is_not_section(self):


### PR DESCRIPTION
## Overview

Board and section names containing non-Latin characters (Japanese, Chinese, Cyrillic, etc.) were rejected with `InvalidBoardUrlError`. Browsers percent-encode these characters in URLs, for example a Japanese board name becomes `%E3%83%86%E3%82%B9%E3%83%88-2`, but the parser validated segments as raw ASCII before decoding them, so any `%XX` sequence failed the `[A-Za-z0-9_-]+` check.

Closes #72.

## API

* 756c08a - `_parse_board_url` and `_parse_section_url` call `unquote()` on each path segment before validation; validation regex relaxed to `[\w-]+` to accept Unicode letters; duplicate `urlsplit/urlunsplit` import removed from `api.py`
* e1725e2 - regression tests added for percent-encoded and raw-Unicode board URLs, and percent-encoded section URLs; synthetic katakana slug used as test data with no real user identifiers
