### PR TITLE
test: enforce offline test suite and add live API canary

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,26 @@
+name: Integration (live Pinterest API)
+
+# Canary run against the real Pinterest API so we get alerted when the
+# unofficial API drifts. Runs weekly and on demand only, never on push, to
+# keep load on Pinterest negligible.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  integration:
+    name: Run live integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run integration tests
+        run: pytest -m integration -v

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Working examples covering:
 
 - **[CLI Guide](https://github.com/sean1832/pinterest-dl/blob/main/doc/CLI.md)** - Complete command-line interface documentation
 - **[Python API Guide](https://github.com/sean1832/pinterest-dl/blob/main/doc/API.md)** - Programmatic usage examples and patterns
+- **[Testing Guide](https://github.com/sean1832/pinterest-dl/blob/main/doc/TESTING.md)** - Offline-by-default test policy and live integration tests
 - **[Contributing Guidelines](https://github.com/sean1832/pinterest-dl/blob/main/CONTRIBUTING.md)** - How to contribute to the project
 
 ## 🤝 Contributing

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,0 +1,97 @@
+# Testing
+
+## Policy: the default suite never touches the network
+
+Pinterest's API is unofficial and reverse engineered. Running the test suite
+must not send requests to Pinterest. Hitting their servers on every test run is
+wasteful, risks rate limiting, and is not a polite thing to do to a service we
+do not own. Unit tests verify *our* code, so they have no reason to go online.
+
+The default suite is therefore fully offline and runs with no internet
+connection. This is enforced automatically, not by convention.
+
+## Running tests
+
+```bash
+# Run the default (offline) suite
+pytest
+
+# Verbose
+pytest -v
+
+# A single file or test
+pytest tests/test_pinterest_api.py
+pytest tests/test_pinterest_api.py::TestPinterestAPIUrlParsing::test_parse_pin_id_valid_url
+```
+
+Install the test tools first if needed:
+
+```bash
+pip install -e ".[dev]"
+```
+
+## How offline is enforced
+
+`tests/conftest.py` has an autouse fixture, `_offline_guard`, that applies to
+every test:
+
+1. It stubs `Api._get_default_cookies` so constructing `Api(...)` no longer
+   fetches default cookies from `https://www.pinterest.com`. Without this, every
+   `Api(...)` in a test fires a real request as a side effect of `__init__`.
+2. It blocks real outbound socket connections. Loopback (`127.*`, `::1`,
+   `localhost`) is still allowed so local machinery such as the asyncio event
+   loop and Playwright keeps working. Any other connection attempt raises:
+
+   ```
+   RuntimeError: Network access is not allowed in unit tests.
+   Mark the test with @pytest.mark.integration to hit the real API.
+   ```
+
+This means a new test that accidentally reaches the network fails loudly instead
+of silently hammering Pinterest.
+
+## Integration tests (the API canary)
+
+Unit tests cannot detect Pinterest changing its API, because they assert against
+our own parsing of fixed inputs. To catch API drift we keep a small set of
+deliberate live tests in `tests/integration/`, marked with
+`@pytest.mark.integration`. These are excluded from the default run (see
+`addopts` in `pyproject.toml`) and are exempt from the offline guard.
+
+Run them only when you mean to:
+
+```bash
+pytest -m integration
+```
+
+Keep this suite small. A couple of real assertions are enough to detect drift;
+more requests just add load on Pinterest without adding signal.
+
+### Scheduled runs
+
+`.github/workflows/integration.yml` runs the integration suite on a weekly cron
+and on manual dispatch, never on push. One controlled run a week is a negligible
+load on Pinterest, and it alerts us when the unofficial API changes.
+
+## Writing a test that needs the network
+
+Default to offline. Mock the boundary (the HTTP client, `requests`, `m3u8.load`,
+`subprocess.run`) and test your logic against the mocked response. Most of the
+suite already does this.
+
+Only when the point of the test is to verify Pinterest's real behavior should it
+go online. In that case put it under `tests/integration/` and mark it:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.integration
+
+def test_something_live():
+    ...
+```
+
+## See Also
+
+- [Dump Mode](DUMP.md) - capture real API requests/responses for debugging and analysis
+- [API Documentation](API.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,9 @@ version = { attr = "pinterest_dl.__version__" }
 
 [tool.setuptools]
 packages = { find = { include = ["pinterest_dl*"] } }
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: hits the real Pinterest network; run deliberately, not in the default suite",
+]
+addopts = "-m 'not integration'"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,17 +1,26 @@
 # Tests
 
+The default suite is **offline** and makes no requests to Pinterest. This is
+enforced by an autouse fixture in `conftest.py`; a test that reaches the network
+fails loudly. Live API tests live in `tests/integration/` behind the
+`integration` marker and are excluded by default.
+
+See the [Testing Guide](../doc/TESTING.md) for the full policy, rationale, and
+how to write tests that need the network.
+
 ## Running Tests
 
 ```bash
-# Run all tests
-pytest tests/
+# Run the default (offline) suite
+pytest
 
-# Run with verbose output
-pytest tests/ -v
+# Verbose
+pytest -v
 
-# Run specific test file
+# A single file or test
 pytest tests/test_pinterest_media.py
-
-# Run specific test
 pytest tests/test_pinterest_api.py::TestPinterestAPIUrlParsing::test_parse_pin_id_valid_url
+
+# Live integration tests (hit the real Pinterest API; run deliberately)
+pytest -m integration
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,43 @@
 """Pytest configuration and shared fixtures."""
 
+import socket
+
 import pytest
 
+from pinterest_dl.api.api import Api
 from pinterest_dl.domain.media import PinterestMedia, VideoStreamInfo
+
+
+@pytest.fixture(autouse=True)
+def _offline_guard(request, monkeypatch):
+    """Keep the default suite fully offline.
+
+    Constructing Api() fetches default cookies over the network, which would
+    hit Pinterest on every test run. Stub that out and block any other socket
+    connection so no unit test can accidentally reach the network. Tests marked
+    with @pytest.mark.integration are exempt and run against the real API.
+    """
+    if request.node.get_closest_marker("integration"):
+        return
+
+    monkeypatch.setattr(Api, "_get_default_cookies", staticmethod(lambda url: {}))
+
+    # Block real outbound connections, but allow loopback: asyncio/Playwright
+    # build their event-loop self-pipe from a 127.0.0.1 socketpair on Windows.
+    real_connect = socket.socket.connect
+
+    def guarded_connect(self, address, *args, **kwargs):
+        host = address[0] if isinstance(address, tuple) else address
+        if isinstance(host, str) and (
+            host == "localhost" or host == "::1" or host.startswith("127.")
+        ):
+            return real_connect(self, address, *args, **kwargs)
+        raise RuntimeError(
+            "Network access is not allowed in unit tests. "
+            "Mark the test with @pytest.mark.integration to hit the real API."
+        )
+
+    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
 
 
 @pytest.fixture

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,6 @@
+"""Integration tests that hit the real Pinterest network.
+
+Excluded from the default suite (see pyproject.toml addopts). Run with:
+
+    pytest -m integration
+"""

--- a/tests/integration/test_pinterest_live.py
+++ b/tests/integration/test_pinterest_live.py
@@ -1,0 +1,34 @@
+"""Live checks against the real Pinterest API.
+
+These are the canary tests: they hit Pinterest for real so we get alerted when
+the unofficial API changes shape. They are excluded from the default suite and
+run deliberately (locally or on a schedule):
+
+    pytest -m integration
+
+Keep this file small. A couple of real assertions are enough to detect drift;
+more requests just add load on Pinterest without adding signal.
+"""
+
+import pytest
+
+from pinterest_dl import PinterestDL
+from pinterest_dl.api.api import Api
+
+pytestmark = pytest.mark.integration
+
+
+def test_default_cookies_endpoint_serves_cookies():
+    """The base URL still hands out cookies (Api.__init__ depends on this)."""
+    cookies = Api._get_default_cookies("https://www.pinterest.com")
+    assert isinstance(cookies, dict)
+    assert cookies, "Pinterest returned no default cookies; the endpoint may have changed"
+
+
+def test_search_scrape_returns_usable_images():
+    """End-to-end: search resource + response parsing still yield image URLs."""
+    results = PinterestDL.with_api().scrape("https://www.pinterest.com/search/pins/?q=nature", num=5)
+
+    assert results, "Search returned no media; the API response shape may have changed"
+    for media in results:
+        assert media.src.startswith("https://"), f"Unexpected image src: {media.src!r}"

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -60,15 +60,13 @@ class TestPinterestAPIUrlParsing:
 
     def test_parse_board_url_with_percent_encoded_unicode(self):
         """Percent-encoded Unicode board slugs should decode (issue #72)."""
-        with patch.object(Api, "_get_default_cookies", return_value={}):
-            api = Api("https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/")
+        api = Api("https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/")
         assert api.username == "testuser"
         assert api.boardname == self.UNICODE_BOARD_SLUG
 
     def test_parse_board_url_with_raw_unicode(self):
         """Non-encoded Unicode board slugs should also parse."""
-        with patch.object(Api, "_get_default_cookies", return_value={}):
-            api = Api(f"https://www.pinterest.com/testuser/{self.UNICODE_BOARD_SLUG}/")
+        api = Api(f"https://www.pinterest.com/testuser/{self.UNICODE_BOARD_SLUG}/")
         assert api.username == "testuser"
         assert api.boardname == self.UNICODE_BOARD_SLUG
 
@@ -131,10 +129,7 @@ class TestPinterestAPIUrlParsing:
 
     def test_parse_section_url_with_percent_encoded_unicode(self):
         """Percent-encoded Unicode board/section slugs should decode (issue #72)."""
-        with patch.object(Api, "_get_default_cookies", return_value={}):
-            api = Api(
-                "https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/live/"
-            )
+        api = Api("https://www.pinterest.com/testuser/%E3%83%86%E3%82%B9%E3%83%88-2/live/")
         assert api.username == "testuser"
         assert api.boardname == self.UNICODE_BOARD_SLUG
         assert api.section_slug == "live"
@@ -161,21 +156,20 @@ class TestPinterestAPIUrlParsing:
 
 class TestScrapePinFallbacks:
     def test_scrape_falls_back_to_page_when_api_data_is_invalid(self):
-        with patch.object(Api, "_get_default_cookies", return_value={}):
-            scraper = ApiScraper()
-            expected = PinterestMedia(
-                id=123456789012345,
-                src="https://i.pinimg.com/originals/test.jpg",
-                alt="caption",
-                origin="https://www.pinterest.com/pin/123456789012345/",
-                resolution=(1200, 1800),
-            )
+        scraper = ApiScraper()
+        expected = PinterestMedia(
+            id=123456789012345,
+            src="https://i.pinimg.com/originals/test.jpg",
+            alt="caption",
+            origin="https://www.pinterest.com/pin/123456789012345/",
+            resolution=(1200, 1800),
+        )
 
-            with (
-                patch.object(Api, "get_main_image", side_effect=ValueError("bad json")),
-                patch.object(ApiScraper, "_get_main_pin_from_page", return_value=expected) as page_fallback,
-            ):
-                items = scraper.scrape("https://www.pinterest.com/pin/123456789012345/", num=1)
+        with (
+            patch.object(Api, "get_main_image", side_effect=ValueError("bad json")),
+            patch.object(ApiScraper, "_get_main_pin_from_page", return_value=expected) as page_fallback,
+        ):
+            items = scraper.scrape("https://www.pinterest.com/pin/123456789012345/", num=1)
 
         assert items == [expected]
         page_fallback.assert_called_once()
@@ -188,18 +182,17 @@ class TestScrapePinFallbacks:
         </html>
         """
 
-        with patch.object(Api, "_get_default_cookies", return_value={}):
-            scraper = ApiScraper()
+        scraper = ApiScraper()
 
-            with (
-                patch.object(Api, "get_main_image", side_effect=EmptyResponseError("no data")),
-                patch.object(Api, "get_pin_page", return_value=html),
-            ):
-                items = scraper.scrape(
-                    "https://www.pinterest.com/pin/123456789012345/",
-                    num=1,
-                    min_resolution=(1000, 1000),
-                )
+        with (
+            patch.object(Api, "get_main_image", side_effect=EmptyResponseError("no data")),
+            patch.object(Api, "get_pin_page", return_value=html),
+        ):
+            items = scraper.scrape(
+                "https://www.pinterest.com/pin/123456789012345/",
+                num=1,
+                min_resolution=(1000, 1000),
+            )
 
         assert items == []
 


### PR DESCRIPTION
## Why

Every `Api(...)` constructor call fired a real HTTP request to `https://www.pinterest.com` as a side effect of fetching default cookies. This meant the test suite was hitting Pinterest's servers on every run -- wasteful, ethically poor, and a latent rate-limit risk. This change makes the default suite fully offline and adds a deliberate, scheduled canary to detect API drift instead.


## Tests

- c05032a - adds `_offline_guard` autouse fixture in `tests/conftest.py` that stubs `Api._get_default_cookies` and blocks outbound socket connections; loopback is still allowed so asyncio and Playwright keep working
- c05032a - adds `tests/integration/` with two live canary tests behind `@pytest.mark.integration`: one checks the cookie endpoint, one does an end-to-end search scrape
- c05032a - removes redundant `patch.object(Api, "_get_default_cookies", ...)` from five unit tests now covered globally by the autouse fixture

## CI / Config

- 01ac424 - adds `pyproject.toml` pytest marker and `addopts = "-m 'not integration'"` so integration tests are excluded from every normal `pytest` run
- 01ac424 - adds `.github/workflows/integration.yml` cron (Mondays 06:00 UTC) and `workflow_dispatch`; never runs on push, so Pinterest sees at most one controlled probe per week

## Docs

- 0b34080 - adds `doc/TESTING.md` covering the offline policy, how enforcement works, and how to write tests that need the network
- 0b34080 - updates `README.md` and `tests/README.md` to link to the new guide

## Notes

The socket guard allows loopback (`127.*`, `::1`, `localhost`) because Windows builds the asyncio event-loop self-pipe via a `127.0.0.1` socketpair inside `socket.socketpair()`. Blocking it outright caused the Playwright browser-launch test to fail with the offline error even though it never touches Pinterest.

Unit tests assert against our own parsing and mocked responses, so they cannot detect Pinterest changing their API. The integration canary exists for exactly that purpose and is kept intentionally small -- two assertions are enough signal; more requests would just add unnecessary load.
