### PR TITLE
fix(scraper): ensure pin is always first result for pin urls

### DIFF
--- a/pinterest_dl/scrapers/api_scraper.py
+++ b/pinterest_dl/scrapers/api_scraper.py
@@ -120,9 +120,31 @@ class ApiScraper:
         Returns:
             List[PinterestMedia]: List of scraped PinterestMedia objects.
         """
-        medias = self._collect(
-            self.iter_scrape(url, min_resolution, delay, caption_from_title), num, on_progress
-        )
+        api = self._create_api(url)
+        if api.query is not None:
+            source = self.iter_search(api.query, min_resolution, delay, caption_from_title)
+            medias = self._collect(source, num, on_progress)
+        elif api.is_pin:
+            # The main pin is always the first result. Related pins only fill
+            # the remainder when num > 1; a filtered-out pin returns [] not a related pin.
+            main = self._scrape_one_pin(api, min_resolution, caption_from_title)
+            medias = [main] if main else []
+            if main and on_progress:
+                on_progress(main)
+            if num > 1:
+                source = self._pump(
+                    lambda size, bm: self._get_images(
+                        api, size, bm, min_resolution, caption_from_title=caption_from_title
+                    ),
+                    delay,
+                )
+                medias.extend(self._collect(source, num - len(medias), on_progress))
+        elif api.is_section:
+            source = self._iter_section(api, min_resolution, delay, caption_from_title)
+            medias = self._collect(source, num, on_progress)
+        else:
+            source = self._iter_board(api, min_resolution, delay, caption_from_title)
+            medias = self._collect(source, num, on_progress)
         if self.verbose:
             self._display_images(medias)
         logger.info(f"Successfully scraped {len(medias)} media items from {url}")

--- a/tests/test_pinterest_api.py
+++ b/tests/test_pinterest_api.py
@@ -187,7 +187,7 @@ class TestScrapePinFallbacks:
         with (
             patch.object(Api, "get_main_image", side_effect=EmptyResponseError("no data")),
             patch.object(Api, "get_pin_page", return_value=html),
-            patch.object(ApiScraper, "_pump", return_value=iter([])),
+            patch.object(ApiScraper, "_pump") as pump,
         ):
             items = scraper.scrape(
                 "https://www.pinterest.com/pin/123456789012345/",
@@ -196,6 +196,7 @@ class TestScrapePinFallbacks:
             )
 
         assert items == []
+        pump.assert_not_called()
 
 
 class TestApiScraperRouting:


### PR DESCRIPTION
scrape() with a pin URL previously fell through to related pins when the main pin was filtered out (e.g. by min_resolution), returning a related pin instead of []. The main pin is now always the first result; related pins only fill the remainder when num > 1.