### PR TITLE
Add tqdm progress bar to CLI scrape phase

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -122,6 +122,23 @@ python examples/dump_mode.py
 
 ---
 
+### 7. `streaming_and_progress.py`
+**Lazy iterator API and progress callbacks**
+
+Examples included:
+- Stream `iter_scrape` with your own tqdm bar
+- Process items while streaming and stop early
+- `on_progress` callback with eager `scrape()`
+- Stream search results with `iter_search`
+- Route progress to a custom sink
+
+**Quick start:**
+```bash
+python examples/streaming_and_progress.py
+```
+
+---
+
 ## Running Examples
 
 ### Run Individual Examples
@@ -235,6 +252,22 @@ items = PinterestDL.with_api().scrape_and_download(
     download_streams=True,  # Download videos
     caption="json",         # Save metadata as JSON
 )
+```
+
+### Workflow 6: Stream results and drive your own progress bar
+```python
+import itertools
+from tqdm import tqdm
+from pinterest_dl import PinterestDL
+
+scraper = PinterestDL.with_api()
+num = 30
+
+# iter_scrape yields lazily; islice caps the count, tqdm shows progress
+medias = list(tqdm(
+    itertools.islice(scraper.iter_scrape("YOUR_URL"), num),
+    total=num,
+))
 ```
 
 ---

--- a/examples/streaming_and_progress.py
+++ b/examples/streaming_and_progress.py
@@ -1,0 +1,150 @@
+"""
+Example: Streaming and Progress Reporting
+=========================================
+
+This example demonstrates the lazy iterator API (iter_scrape / iter_search)
+and the on_progress callback. These let library callers stream results, drive
+their own progress bar, and stop early - without the scraper forcing a progress
+bar on them.
+"""
+
+import itertools
+
+from tqdm import tqdm
+
+from pinterest_dl import PinterestDL
+
+# ============================================================================
+# Configuration - Change these to your actual Pinterest links / queries
+# ============================================================================
+BOARD_URL = "https://www.pinterest.com/username/board-name/"
+PIN_URL = "https://www.pinterest.com/pin/12345678/"
+SEARCH_QUERY = "mountain landscapes"
+
+
+def example_1_stream_with_tqdm():
+    """Wrap iter_scrape with your own tqdm bar.
+
+    iter_scrape yields PinterestMedia lazily and never creates a progress bar
+    itself, so the caller decides how progress is shown. itertools.islice caps
+    how many items are pulled from the otherwise open-ended stream.
+    """
+    print("Example 1: Stream with your own tqdm bar")
+    print("-" * 50)
+
+    scraper = PinterestDL.with_api()
+    num = 30
+
+    medias = list(
+        tqdm(
+            itertools.islice(scraper.iter_scrape(BOARD_URL), num),
+            total=num,
+            desc="Scraping",
+        )
+    )
+
+    print(f"> Streamed {len(medias)} items")
+    print()
+
+
+def example_2_process_while_streaming():
+    """Act on each item as it arrives instead of collecting a list.
+
+    Because iteration is lazy, results can be handled before the whole board is
+    scraped, and iteration can stop as soon as enough have been collected. No
+    further requests are made after the loop breaks.
+    """
+    print("Example 2: Process while streaming")
+    print("-" * 50)
+
+    scraper = PinterestDL.with_api()
+
+    for i, media in enumerate(scraper.iter_scrape(BOARD_URL), start=1):
+        print(f"  [{i}] {media.src}")
+        if i >= 5:
+            break
+
+    print()
+
+
+def example_3_on_progress_callback():
+    """Use the on_progress callback with the eager scrape() API.
+
+    scrape() returns the full list, but on_progress fires once per scraped item
+    so a bar can be driven without switching to iter_scrape.
+    """
+    print("Example 3: on_progress callback")
+    print("-" * 50)
+
+    scraper = PinterestDL.with_api()
+    num = 20
+
+    with tqdm(total=num, desc="Scraping") as pbar:
+
+        def advance(_media):
+            pbar.update(1)
+
+        medias = scraper.scrape(url=BOARD_URL, num=num, on_progress=advance)
+
+    print(f"> Scraped {len(medias)} items")
+    print()
+
+
+def example_4_stream_search():
+    """Stream search results lazily with iter_search."""
+    print("Example 4: Stream search results")
+    print("-" * 50)
+
+    scraper = PinterestDL.with_api()
+    num = 15
+
+    medias = list(
+        tqdm(
+            itertools.islice(scraper.iter_search(SEARCH_QUERY), num),
+            total=num,
+            desc="Searching",
+        )
+    )
+
+    print(f"> Streamed {len(medias)} search results")
+    print()
+
+
+def example_5_custom_progress_sink():
+    """Route progress somewhere other than a terminal bar.
+
+    on_progress receives each PinterestMedia, so the callback can push to a
+    queue, a websocket, a GUI, or a counter - anything the consumer wants.
+    """
+    print("Example 5: Custom progress sink")
+    print("-" * 50)
+
+    scraper = PinterestDL.with_api()
+    seen = []
+
+    def on_progress(media):
+        seen.append(media.src)
+        print(f"  scraped {len(seen)}: {media.src}")
+
+    medias = scraper.scrape(url=PIN_URL, num=5, on_progress=on_progress)
+
+    print(f"> Scraped {len(medias)} items, tracked {len(seen)} in the sink")
+    print()
+
+
+if __name__ == "__main__":
+    print("=" * 50)
+    print("Pinterest-DL Streaming and Progress Examples")
+    print("=" * 50)
+    print()
+
+    # Run examples (comment out the ones you don't need)
+    example_1_stream_with_tqdm()
+    example_2_process_while_streaming()
+    example_3_on_progress_callback()
+    example_4_stream_search()
+    example_5_custom_progress_sink()
+
+    print("=" * 50)
+    print("All streaming examples completed!")
+    print("=" * 50)

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -1,9 +1,11 @@
 import argparse
 import sys
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from getpass import getpass
 from pathlib import Path
-from typing import List
+from typing import Callable, Iterator, List
+
+from tqdm import tqdm
 
 from pinterest_dl import PinterestDL, __description__, __version__
 from pinterest_dl.common import io
@@ -28,6 +30,23 @@ def parse_resolution(resolution: str) -> tuple[int, int]:
         return width, height
     except ValueError:
         raise ValueError("Invalid resolution format. Use 'width x height'.")
+
+
+@contextmanager
+def scrape_progress(
+    total: int, desc: str, disable: bool
+) -> Iterator[Callable[[PinterestMedia], None]]:
+    """Yield an on_progress callback that drives a tqdm bar for the scrape phase.
+
+    The download phase manages its own bar, so this covers scraping only. In
+    verbose mode the bar is disabled so log lines show instead.
+    """
+    with tqdm(total=total, desc=desc, disable=disable) as pbar:
+
+        def advance(_media: PinterestMedia) -> None:
+            pbar.update(1)
+
+        yield advance
 
 
 def combine_inputs(positionals: List[str], files: List[str] | None) -> List[str]:
@@ -346,20 +365,22 @@ def main() -> None:
                         dump=args.dump,
                     ).with_cookies_path(args.cookies)
                     download = api.related_and_download if related_only else api.scrape_and_download
-                    imgs = download(
-                        url,
-                        args.output,
-                        num,
-                        download_streams=args.video,
-                        skip_remux=args.skip_remux,
-                        min_resolution=parse_resolution(args.resolution)
-                        if args.resolution
-                        else (0, 0),
-                        cache_path=args.cache,
-                        caption=args.caption,
-                        delay=args.delay,
-                        caption_from_title=args.cap_from_title,
-                    )
+                    with scrape_progress(num, "Scraping", args.verbose) as on_progress:
+                        imgs = download(
+                            url,
+                            args.output,
+                            num,
+                            download_streams=args.video,
+                            skip_remux=args.skip_remux,
+                            min_resolution=parse_resolution(args.resolution)
+                            if args.resolution
+                            else (0, 0),
+                            cache_path=args.cache,
+                            caption=args.caption,
+                            delay=args.delay,
+                            caption_from_title=args.cap_from_title,
+                            on_progress=on_progress,
+                        )
                 if imgs and len(imgs) != num:
                     print(
                         f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {num}). Some may have been duplicates, filtered, or failed to download."
@@ -388,15 +409,14 @@ def main() -> None:
                             "Warning: Incognito and headful mode is only available for browser clients."
                         )
 
-                    imgs = (
-                        PinterestDL.with_api(
-                            timeout=args.timeout,
-                            verbose=args.verbose,
-                            ensure_alt=args.ensure_cap,
-                            dump=args.dump,
-                        )
-                        .with_cookies_path(args.cookies)
-                        .search_and_download(
+                    api = PinterestDL.with_api(
+                        timeout=args.timeout,
+                        verbose=args.verbose,
+                        ensure_alt=args.ensure_cap,
+                        dump=args.dump,
+                    ).with_cookies_path(args.cookies)
+                    with scrape_progress(args.num, "Searching", args.verbose) as on_progress:
+                        imgs = api.search_and_download(
                             query,
                             args.output,
                             args.num,
@@ -409,8 +429,8 @@ def main() -> None:
                             caption=args.caption,
                             delay=args.delay,
                             caption_from_title=args.cap_from_title,
+                            on_progress=on_progress,
                         )
-                    )
                     if imgs and len(imgs) != args.num:
                         print(
                             f"Warning: Only ({len(imgs)}) images were successfully downloaded from {query} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."


### PR DESCRIPTION
## Why

The CLI gave no visual feedback during the scraping phase, which can be slow on large boards. The scraper layer already accepted `on_progress` and exposed `iter_scrape`/`iter_search` (added in prior commits), but the CLI never wired them up. This closes that gap with a tqdm bar that matches the existing download-phase bar.


## CLI

- 522b1e6 - adds `scrape_progress()` context manager in `cli.py` that creates a tqdm bar and yields an `on_progress` callback; wires it into both `scrape_and_download` and `search_and_download` paths in `main()`
- bar is disabled automatically when `--verbose` is passed, so log lines show instead of the bar

## Docs

- b72daf3 - adds `examples/streaming_and_progress.py` with five runnable examples covering `iter_scrape`, `iter_search`, `on_progress`, early-exit streaming, and custom progress sinks
- updates `examples/README.md` with a Workflow 6 snippet and an entry for the new example file

## Notes

`scrape_progress` is a context manager rather than a plain factory so the tqdm bar is always closed even if the scrape raises. The download phase manages its own bar independently, so the two bars appear sequentially rather than nested.
