### PR TITLE
Harden --json mode: cache, clean stdout, structured errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ pinterest-dl scrape "<pin_url>" --video -o ./output
 # Reach a private board: log in once, then pass the cookies
 pinterest-dl login -o cookies.json
 pinterest-dl scrape "<private_board_url>" -c cookies.json -o ./output
+
+# Machine-readable output: emit JSON to stdout (no -o means metadata only)
+pinterest-dl scrape "<pin_url>" -n 10 --json | jq '.results[0].items[].src'
 ```
 
 Read the full [CLI guide](https://github.com/sean1832/pinterest-dl/blob/main/doc/CLI.md) for every command and option.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -88,6 +88,7 @@ cat urls.txt | pinterest-dl scrape -f - [options]
 | `--backend [playwright/selenium]` (**NEW**) | Browser automation backend (for browser clients)          | `playwright`   |
 | `--headful`                                 | Show browser window (browser clients only)                | -              |
 | `--incognito`                               | Use incognito mode (browser clients only)                 | -              |
+| `--json` (**NEW**)                          | Print structured JSON to stdout instead of human-readable output | -       |
 | `--verbose`                                 | Enable debug output                                       | -              |
 
 > [!TIP]
@@ -129,6 +130,7 @@ cat queries.txt | pinterest-dl search -f - [options]
 | `--ensure-cap`                       | Require alt text on every image                             | -              |
 | `--cap-from-title`                   | Use image title as caption                                  | -              |
 | `--dump [PATH]` (**NEW**)            | Dump API requests/responses to PATH (default: `.dump`)      | -              |
+| `--json` (**NEW**)                   | Print structured JSON to stdout instead of human-readable output | -         |
 | `--verbose`                          | Enable debug output                                         | -              |
 
 ---
@@ -149,4 +151,31 @@ pinterest-dl download <cache.json> [options]
 | `--skip-remux` (**NEW**)             | Skip ffmpeg remux, output raw .ts file (no ffmpeg needed) | -                   |
 | `--caption [txt/json/metadata/none]` | Caption format                                            | `none`              |
 | `--ensure-cap`                       | Require alt text on every image                           | -                   |
+| `--json` (**NEW**)                   | Print structured JSON to stdout instead of human-readable output | -            |
 | `--verbose`                          | Enable debug output                                       | -                   |
+
+---
+
+### JSON output (`--json`)
+
+`scrape`, `search`, and `download` accept `--json` for machine-readable output. When set:
+
+- Human-readable text is suppressed; a single JSON object is written to stdout on completion.
+- Errors are written to stderr as `{"error": <message>}`, so stdout stays clean for piping.
+- Without `-o`/`--output`, no files are downloaded -- only metadata is returned. With `--output`, files are downloaded and each item gains a `local_path`.
+- `--cache` still writes the cache file in JSON mode.
+
+Output shape:
+
+```jsonc
+// scrape / search
+{"command": "scrape", "results": [{"input": "<url>", "items": [ ... ]}]}
+
+// download
+{"command": "download", "input": "cache.json", "items": [ ... ]}
+```
+
+```bash
+# Pipe scraped metadata into jq without downloading anything
+pinterest-dl scrape "<pin_url>" -n 10 --json | jq '.results[0].items[].src'
+```

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -95,6 +95,11 @@ def emit_json(payload: Any) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def emit_json_error(message: str) -> None:
+    """Print a machine-readable error to stderr, keeping stdout clean for piping."""
+    print(json.dumps({"error": message}), file=sys.stderr)
+
+
 def write_media_cache(items: List[PinterestMedia], cache_path: str | None) -> None:
     """Persist scraped media to the cache file when a path is configured.
 
@@ -569,14 +574,19 @@ def main() -> None:
         else:
             parser.print_help()
     except KeyboardInterrupt:
-        if not json_mode:
+        if json_mode:
+            emit_json_error("Operation cancelled by user.")
+        else:
             print("\nOperation cancelled by user.")
         sys.exit(1)
     except Exception as e:
         # Log with full traceback when verbose, show user-friendly message otherwise
-        if getattr(args, "verbose", False):
+        verbose = getattr(args, "verbose", False)
+        if verbose:
             logger.error(f"An error occurred: {e}", exc_info=True)
-        else:
+        if json_mode:
+            emit_json_error(str(e))
+        elif not verbose:
             print(f"\nError: {e}", file=sys.stderr)
             print("\nRun with --verbose for full traceback.", file=sys.stderr)
         sys.exit(1)

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -95,6 +95,16 @@ def emit_json(payload: Any) -> None:
     print(json.dumps(payload, indent=2))
 
 
+def write_media_cache(items: List[PinterestMedia], cache_path: str | None) -> None:
+    """Persist scraped media to the cache file when a path is configured.
+
+    Used by the --json no-output paths, which bypass scrape_and_download (and thus
+    its built-in caching) to keep stdout clean.
+    """
+    if cache_path:
+        io.write_json(media_list_to_dicts(items), cache_path, indent=4)
+
+
 def validate_cookies_authenticated(cookies: list[dict]) -> bool:
     """Check if cookies contain authenticated Pinterest session.
 
@@ -346,6 +356,7 @@ def main() -> None:
                             )
                             if json_mode and not args.output:
                                 imgs = scraper.scrape(url, num)
+                                write_media_cache(imgs, args.cache)
                             else:
                                 imgs = scraper.scrape_and_download(
                                     url,
@@ -372,6 +383,7 @@ def main() -> None:
                             scraper = scraper.with_cookies_path(args.cookies)
                             if json_mode and not args.output:
                                 imgs = scraper.scrape(url, num)
+                                write_media_cache(imgs, args.cache)
                             else:
                                 imgs = scraper.scrape_and_download(
                                     url,
@@ -415,8 +427,7 @@ def main() -> None:
                             delay=args.delay,
                             caption_from_title=args.cap_from_title,
                         )
-                        if args.cache:
-                            io.write_json(media_list_to_dicts(imgs), args.cache, indent=4)
+                        write_media_cache(imgs, args.cache)
                     else:
                         download = api.related_and_download if related_only else api.scrape_and_download
                         with scrape_progress(num, "Scraping", args.verbose or json_mode) as on_progress:
@@ -491,8 +502,7 @@ def main() -> None:
                             delay=args.delay,
                             caption_from_title=args.cap_from_title,
                         )
-                        if args.cache:
-                            io.write_json(media_list_to_dicts(imgs), args.cache, indent=4)
+                        write_media_cache(imgs, args.cache)
                     else:
                         with scrape_progress(args.num, "Searching", args.verbose or json_mode) as on_progress:
                             imgs = api.search_and_download(

--- a/pinterest_dl/scrapers/playwright_scraper.py
+++ b/pinterest_dl/scrapers/playwright_scraper.py
@@ -152,7 +152,7 @@ class PlaywrightScraper:
             raise ValueError("Invalid cookies file format. Expected a list of cookies.")
 
         if self.verbose:
-            print("Navigate to Pinterest homepage before loading cookies.")
+            logger.debug("Navigate to Pinterest homepage before loading cookies.")
 
         # Navigate to Pinterest first (required before adding cookies)
         self.page.goto("https://www.pinterest.com")
@@ -164,7 +164,7 @@ class PlaywrightScraper:
 
         # Add cookies to context (type: ignore for Playwright's strict typing)
         self.browser.context.add_cookies(pw_cookies)  # type: ignore[arg-type]
-        print(f"Loaded cookies from {cookies_path}")
+        logger.info(f"Loaded cookies from {cookies_path}")
 
         time.sleep(wait_sec)
         return self

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -137,4 +137,4 @@ class TestJsonMode:
 
         assert exc.value.code == 1
         assert stdout.getvalue() == ""
-        assert "Error: boom" in stderr.getvalue()
+        assert json.loads(stderr.getvalue()) == {"error": "boom"}


### PR DESCRIPTION
## Why

The initial `--json` implementation left three gaps that break machine-readable consumption: `--cache` was silently dropped on browser clients, the Playwright scraper leaked cookie-loading text onto stdout, and failures emitted unparseable plain text. These fixes make `--json` reliable to pipe and parse, with matching docs.

## CLI

- c3a7823 - honors --cache in browser `--json` no-output mode; the selenium and playwright paths bypassed scrape_and_download (and its built-in caching), so a new write_media_cache helper now backs all four no-output JSON branches
- a71d6ca - `writes {"error": <message>}` to stderr on failure instead of plain text, covering both exceptions and KeyboardInterrupt, so stdout stays clean for piping

## Scrapers

- 03c9f9b - routes Playwright cookie-loading messages through the logger instead of print, matching webdriver_scraper and keeping browser-client `--json` stdout uncorrupted


## Notes

The structured-error change alters the `--json` failure contract from plain text to a JSON object on stderr; stdout remains empty on failure, so existing "check exit code, parse stdout" pipelines are unaffected. `tests/test_cli_utils.py` is updated to assert the new shape.