### PR TITLE
 Add `--from-browser` cookie extraction and refactor CLI command handlers

### DIFF
--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -165,6 +165,7 @@ def get_parser() -> argparse.ArgumentParser:
     # login command
     login_cmd = cmd.add_parser("login", help="Login to Pinterest and capture cookies")
     login_cmd.add_argument("-o", "--output", default="cookies.json", help="Output path for cookies")
+    login_cmd.add_argument("--from-browser", action="store_true", help="Attempt to load cookies from installed browsers instead of logging in (only Firefox supported due to Chromium encryption)")
     login_cmd.add_argument("--client", default="chromium", choices=["chromium", "firefox"], help="Browser client to login (Playwright)")
     login_cmd.add_argument("--headful", action="store_true", help="Run in headful mode with browser window")
     login_cmd.add_argument("--incognito", action="store_true", help="Incognito mode")
@@ -237,6 +238,14 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def run_login(args: argparse.Namespace) -> None:
+    """Capture Pinterest cookies, either from an installed browser or via Playwright."""
+    if args.from_browser:
+        _run_login_from_browser(args)
+    else:
+        _run_login_playwright(args)
+
+
+def _run_login_playwright(args: argparse.Namespace) -> None:
     """Drive a browser login and persist the captured cookies."""
     email = input("Enter Pinterest email: ")
     password = getpass("Enter Pinterest password: ")
@@ -272,14 +281,25 @@ def run_login(args: argparse.Namespace) -> None:
 
     print("\nNote:")
     print("Please keep your cookies file safe and do not share it with anyone.")
-    print(
-        "You can use these cookies to scrape private boards. Use the '--cookies [file]' option."
-    )
+    print("You can use these cookies to scrape private boards. Use the '--cookies [file]' option.")
     print("Example:")
     print(
         r'    pinterest-dl scrape "https://www.pinterest.com/username/your-board/" "output/pin" -n 10 --cookies .\cookies.json'
     )
     print("\nDone.")
+
+
+def _run_login_from_browser(args: argparse.Namespace) -> None:
+    from pinterest_dl.domain.browser_cookies import load_firefox_cookies
+
+    print("Reading cookies from firefox browser...")
+    cookies = load_firefox_cookies(domain="pinterest.com")
+    if not validate_cookies_authenticated(cookies):
+        print("[WARNING] Cookies do not indicate an authenticated session (_auth != 1).")
+        print("Make sure you are logged in to Pinterest in Firefox.")
+        sys.exit(1)
+    io.write_json(cookies, args.output, 4)
+    print(f"[SUCCESS] Authenticated cookies saved to '{args.output}'")
 
 
 def scrape_url_browser(
@@ -505,9 +525,7 @@ def run_download(args: argparse.Namespace, json_mode: bool) -> None:
         raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
 
     if json_mode:
-        emit_json(
-            {"command": "download", "input": args.input, "items": media_list_to_dicts(kept)}
-        )
+        emit_json({"command": "download", "input": args.input, "items": media_list_to_dicts(kept)})
     else:
         print("\nDone.")
 

--- a/pinterest_dl/cli.py
+++ b/pinterest_dl/cli.py
@@ -236,6 +236,282 @@ def get_parser() -> argparse.ArgumentParser:
 # fmt: on
 
 
+def run_login(args: argparse.Namespace) -> None:
+    """Drive a browser login and persist the captured cookies."""
+    email = input("Enter Pinterest email: ")
+    password = getpass("Enter Pinterest password: ")
+
+    print(f"\nWaiting {args.wait} seconds after login to capture cookies...")
+    print("(Increase with --wait if Pinterest requires more time for authentication)\n")
+
+    # ENABLE images for login (needed for anti-bot)
+    scraper = PinterestDL.with_browser(
+        browser_type=args.client,
+        headless=not args.headful,
+        incognito=args.incognito,
+        verbose=args.verbose,
+        enable_images=True,  # Required for login to work properly
+    )
+    cookies = scraper.login(email, password).get_cookies(after_sec=args.wait)
+    scraper.close()
+
+    if not validate_cookies_authenticated(cookies):
+        print("\n[WARNING] Login may have failed!")
+        print("The captured cookies do not indicate an authenticated session (_auth != 1).")
+        print("This usually means:")
+        print("  - Login credentials were incorrect")
+        print("  - Pinterest blocked the login (captcha, verification required)")
+        print("  - Not enough time to complete login (try --headful and increase --wait)")
+        print(f"  - Current wait time: {args.wait} seconds (increase with --wait 30 or higher)")
+        print("\nCookies will still be saved, but they likely won't work for private boards.")
+        print(f"Saved to: '{args.output}'\n")
+        sys.exit(1)
+
+    io.write_json(cookies, args.output, 4)
+    print(f"\n[SUCCESS] Authenticated cookies saved to '{args.output}'")
+
+    print("\nNote:")
+    print("Please keep your cookies file safe and do not share it with anyone.")
+    print(
+        "You can use these cookies to scrape private boards. Use the '--cookies [file]' option."
+    )
+    print("Example:")
+    print(
+        r'    pinterest-dl scrape "https://www.pinterest.com/username/your-board/" "output/pin" -n 10 --cookies .\cookies.json'
+    )
+    print("\nDone.")
+
+
+def scrape_url_browser(
+    args: argparse.Namespace, url: str, num: int, json_mode: bool
+) -> List[PinterestMedia] | None:
+    """Scrape a single URL with a Playwright browser client."""
+    if args.related_only and not json_mode:
+        print("Warning: --related-only requires the API client; ignoring.")
+
+    # DISABLE images for scraping performance
+    scraper = PinterestDL.with_browser(
+        browser_type=args.client,
+        timeout=args.timeout,
+        headless=not args.headful,
+        incognito=args.incognito,
+        verbose=args.verbose,
+        ensure_alt=args.ensure_cap,
+        enable_images=False,
+    )
+    try:
+        scraper = scraper.with_cookies_path(args.cookies)
+        if json_mode and not args.output:
+            imgs = scraper.scrape(url, num)
+            write_media_cache(imgs, args.cache)
+            return imgs
+        return scraper.scrape_and_download(
+            url,
+            args.output,
+            num,
+            min_resolution=parse_resolution(args.resolution) if args.resolution else None,
+            cache_path=args.cache,
+            caption=args.caption,
+        )
+    finally:
+        scraper.close()
+
+
+def scrape_url_api(
+    args: argparse.Namespace, url: str, num: int, is_pin: bool, json_mode: bool
+) -> List[PinterestMedia] | None:
+    """Scrape a single URL with the reverse-engineered API client."""
+    if (args.incognito or args.headful) and not json_mode:
+        print("Warning: Incognito and headful mode is only available for browser clients.")
+
+    related_only = args.related_only and is_pin
+    if args.related_only and not is_pin and not json_mode:
+        print(f"Warning: --related-only only applies to pin URLs; scraping {url} normally.")
+
+    api = PinterestDL.with_api(
+        timeout=args.timeout,
+        verbose=args.verbose,
+        ensure_alt=args.ensure_cap,
+        dump=args.dump,
+    ).with_cookies_path(args.cookies)
+
+    if json_mode and not args.output:
+        scrape_fn = api.related if related_only else api.scrape
+        imgs = scrape_fn(
+            url,
+            num,
+            min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
+            delay=args.delay,
+            caption_from_title=args.cap_from_title,
+        )
+        write_media_cache(imgs, args.cache)
+        return imgs
+
+    download = api.related_and_download if related_only else api.scrape_and_download
+    with scrape_progress(num, "Scraping", args.verbose or json_mode) as on_progress:
+        return download(
+            url,
+            args.output,
+            num,
+            download_streams=args.video,
+            skip_remux=args.skip_remux,
+            min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
+            cache_path=args.cache,
+            caption=args.caption,
+            delay=args.delay,
+            caption_from_title=args.cap_from_title,
+            on_progress=on_progress,
+        )
+
+
+def run_scrape(args: argparse.Namespace, json_mode: bool) -> None:
+    """Scrape every input URL, downloading or emitting JSON per the flags."""
+    urls = combine_inputs(args.urls, args.file)
+    if not urls:
+        if json_mode:
+            emit_json({"command": "scrape", "results": []})
+        else:
+            print("No URLs provided. Please provide at least one URL.")
+        return
+
+    if args.cookies:
+        check_and_warn_invalid_cookies(args.cookies, quiet=json_mode)
+
+    json_results: list[dict[str, Any]] = []
+    for url in urls:
+        url = sanitize_url(url)
+        is_pin = looks_like_pin_url(url)
+        # Pin URLs default to the pin itself; boards/sections default to a full page.
+        num = args.num if args.num is not None else (1 if is_pin else 100)
+        if not json_mode:
+            print(f"Scraping {url}...")
+
+        if args.client in ("chromium", "firefox"):
+            imgs = scrape_url_browser(args, url, num, json_mode)
+        else:
+            imgs = scrape_url_api(args, url, num, is_pin, json_mode)
+
+        if not json_mode and imgs and len(imgs) != num:
+            print(
+                f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {num}). Some may have been duplicates, filtered, or failed to download."
+            )
+        if json_mode:
+            json_results.append({"input": url, "items": media_list_to_dicts(imgs or [])})
+
+    if json_mode:
+        emit_json({"command": "scrape", "results": json_results})
+    else:
+        print("\nDone.")
+
+
+def search_query_api(
+    args: argparse.Namespace, query: str, json_mode: bool
+) -> List[PinterestMedia] | None:
+    """Run a single search query with the API client."""
+    if (args.incognito or args.headful) and not json_mode:
+        print("Warning: Incognito and headful mode is only available for browser clients.")
+
+    api = PinterestDL.with_api(
+        timeout=args.timeout,
+        verbose=args.verbose,
+        ensure_alt=args.ensure_cap,
+        dump=args.dump,
+    ).with_cookies_path(args.cookies)
+
+    if json_mode and not args.output:
+        imgs = api.search(
+            query,
+            args.num,
+            min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
+            delay=args.delay,
+            caption_from_title=args.cap_from_title,
+        )
+        write_media_cache(imgs, args.cache)
+        return imgs
+
+    with scrape_progress(args.num, "Searching", args.verbose or json_mode) as on_progress:
+        return api.search_and_download(
+            query,
+            args.output,
+            args.num,
+            download_streams=args.video,
+            skip_remux=args.skip_remux,
+            min_resolution=parse_resolution(args.resolution) if args.resolution else (0, 0),
+            cache_path=args.cache,
+            caption=args.caption,
+            delay=args.delay,
+            caption_from_title=args.cap_from_title,
+            on_progress=on_progress,
+        )
+
+
+def run_search(args: argparse.Namespace, json_mode: bool) -> None:
+    """Search every input query, downloading or emitting JSON per the flags."""
+    querys = combine_inputs(args.querys, args.file)
+    if not querys:
+        if json_mode:
+            emit_json({"command": "search", "results": []})
+        else:
+            print("No queries provided. Please provide at least one query.")
+        return
+
+    if args.cookies:
+        check_and_warn_invalid_cookies(args.cookies, quiet=json_mode)
+
+    if args.client in ("chromium", "firefox"):
+        raise NotImplementedError("Search is currently not available for browser clients.")
+
+    json_results: list[dict[str, Any]] = []
+    for query in querys:
+        if not json_mode:
+            print(f"Searching {query}...")
+
+        imgs = search_query_api(args, query, json_mode)
+
+        if not json_mode and imgs and len(imgs) != args.num:
+            print(
+                f"Warning: Only ({len(imgs)}) images were successfully downloaded from {query} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
+            )
+        if json_mode:
+            json_results.append({"input": query, "items": media_list_to_dicts(imgs or [])})
+
+    if json_mode:
+        emit_json({"command": "search", "results": json_results})
+    else:
+        print("\nDone.")
+
+
+def run_download(args: argparse.Namespace, json_mode: bool) -> None:
+    """Download media from a previously cached JSON file and post-process it."""
+    img_datas = io.read_json(args.input)
+    images: List[PinterestMedia] = []
+    for img_data in img_datas if isinstance(img_datas, list) else [img_datas]:
+        img = PinterestMedia.from_dict(img_data)
+        if args.ensure_cap:
+            if img.alt and img.alt.strip():
+                images.append(img)
+        else:
+            images.append(img)
+
+    output_dir = args.output or str(Path(args.input).stem)
+    downloaded_imgs = operations.download_media(images, output_dir, args.video, args.skip_remux)
+
+    kept = operations.prune_images(downloaded_imgs, args.resolution, args.verbose)
+    if args.caption == "txt" or args.caption == "json":
+        operations.add_captions_to_file(kept, output_dir, args.caption, args.verbose)
+    elif args.caption == "metadata":
+        operations.add_captions_to_meta(kept, args.verbose)
+    elif args.caption != "none":
+        raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
+
+    if json_mode:
+        emit_json(
+            {"command": "download", "input": args.input, "items": media_list_to_dicts(kept)}
+        )
+    else:
+        print("\nDone.")
+
+
 def main() -> None:
     parser = get_parser()
     args = parser.parse_args()
@@ -246,277 +522,13 @@ def main() -> None:
 
     try:
         if args.cmd == "login":
-            email = input("Enter Pinterest email: ")
-            password = getpass("Enter Pinterest password: ")
-
-            print(f"\nWaiting {args.wait} seconds after login to capture cookies...")
-            print("(Increase with --wait if Pinterest requires more time for authentication)\n")
-
-            # ENABLE images for login (needed for anti-bot)
-            scraper = PinterestDL.with_browser(
-                browser_type=args.client,
-                headless=not args.headful,
-                incognito=args.incognito,
-                verbose=args.verbose,
-                enable_images=True,  # Required for login to work properly
-            )
-            cookies = scraper.login(email, password).get_cookies(after_sec=args.wait)
-            scraper.close()
-
-            # Validate cookies are authenticated
-            if not validate_cookies_authenticated(cookies):
-                print("\n[WARNING] Login may have failed!")
-                print("The captured cookies do not indicate an authenticated session (_auth != 1).")
-                print("This usually means:")
-                print("  - Login credentials were incorrect")
-                print("  - Pinterest blocked the login (captcha, verification required)")
-                print("  - Not enough time to complete login (try --headful and increase --wait)")
-                print(
-                    f"  - Current wait time: {args.wait} seconds (increase with --wait 30 or higher)"
-                )
-                print(
-                    "\nCookies will still be saved, but they likely won't work for private boards."
-                )
-                print(f"Saved to: '{args.output}'\n")
-                sys.exit(1)
-
-            # save cookies
-            io.write_json(cookies, args.output, 4)
-            print(f"\n[SUCCESS] Authenticated cookies saved to '{args.output}'")
-
-            # print instructions
-            print("\nNote:")
-            print("Please keep your cookies file safe and do not share it with anyone.")
-            print(
-                "You can use these cookies to scrape private boards. Use the '--cookies [file]' option."
-            )
-            print("Example:")
-            print(
-                r'    pinterest-dl scrape "https://www.pinterest.com/username/your-board/" "output/pin" -n 10 --cookies .\cookies.json'
-            )
-            print("\nDone.")
+            run_login(args)
         elif args.cmd == "scrape":
-            urls = combine_inputs(args.urls, args.file)
-            if not urls:
-                if json_mode:
-                    emit_json({"command": "scrape", "results": []})
-                else:
-                    print("No URLs provided. Please provide at least one URL.")
-                return
-
-            # Check cookies validity if provided
-            if args.cookies:
-                check_and_warn_invalid_cookies(args.cookies, quiet=json_mode)
-
-            json_results: list[dict[str, Any]] = []
-
-            for url in urls:
-                url = sanitize_url(url)
-                is_pin = looks_like_pin_url(url)
-                # Pin URLs default to the pin itself; boards/sections default to a full page.
-                num = args.num if args.num is not None else (1 if is_pin else 100)
-                if not json_mode:
-                    print(f"Scraping {url}...")
-                if args.client in ["chromium", "firefox"]:
-                    if args.related_only and not json_mode:
-                        print("Warning: --related-only requires the API client; ignoring.")
-                    # DISABLE images for scraping performance
-                    scraper = PinterestDL.with_browser(
-                        browser_type=args.client,
-                        timeout=args.timeout,
-                        headless=not args.headful,
-                        incognito=args.incognito,
-                        verbose=args.verbose,
-                        ensure_alt=args.ensure_cap,
-                        enable_images=False,  # Disable images for faster scraping
-                    )
-                    try:
-                        scraper = scraper.with_cookies_path(args.cookies)
-                        if json_mode and not args.output:
-                            imgs = scraper.scrape(url, num)
-                            write_media_cache(imgs, args.cache)
-                        else:
-                            imgs = scraper.scrape_and_download(
-                                url,
-                                args.output,
-                                num,
-                                min_resolution=parse_resolution(args.resolution)
-                                if args.resolution
-                                else None,
-                                cache_path=args.cache,
-                                caption=args.caption,
-                            )
-                    finally:
-                        scraper.close()
-                else:
-                    if (args.incognito or args.headful) and not json_mode:
-                        print(
-                            "Warning: Incognito and headful mode is only available for browser clients."
-                        )
-
-                    related_only = args.related_only and is_pin
-                    if args.related_only and not is_pin and not json_mode:
-                        print(
-                            f"Warning: --related-only only applies to pin URLs; scraping {url} normally."
-                        )
-
-                    api = PinterestDL.with_api(
-                        timeout=args.timeout,
-                        verbose=args.verbose,
-                        ensure_alt=args.ensure_cap,
-                        dump=args.dump,
-                    ).with_cookies_path(args.cookies)
-
-                    if json_mode and not args.output:
-                        scrape_fn = api.related if related_only else api.scrape
-                        imgs = scrape_fn(
-                            url,
-                            num,
-                            min_resolution=parse_resolution(args.resolution)
-                            if args.resolution
-                            else (0, 0),
-                            delay=args.delay,
-                            caption_from_title=args.cap_from_title,
-                        )
-                        write_media_cache(imgs, args.cache)
-                    else:
-                        download = api.related_and_download if related_only else api.scrape_and_download
-                        with scrape_progress(num, "Scraping", args.verbose or json_mode) as on_progress:
-                            imgs = download(
-                                url,
-                                args.output,
-                                num,
-                                download_streams=args.video,
-                                skip_remux=args.skip_remux,
-                                min_resolution=parse_resolution(args.resolution)
-                                if args.resolution
-                                else (0, 0),
-                                cache_path=args.cache,
-                                caption=args.caption,
-                                delay=args.delay,
-                                caption_from_title=args.cap_from_title,
-                                on_progress=on_progress,
-                            )
-                if not json_mode and imgs and len(imgs) != num:
-                    print(
-                        f"Warning: Only ({len(imgs)}) images were successfully downloaded from {url} (requested: {num}). Some may have been duplicates, filtered, or failed to download."
-                    )
-                if json_mode:
-                    json_results.append({"input": url, "items": media_list_to_dicts(imgs or [])})
-
-            if json_mode:
-                emit_json({"command": "scrape", "results": json_results})
-            else:
-                print("\nDone.")
+            run_scrape(args, json_mode)
         elif args.cmd == "search":
-            querys = combine_inputs(args.querys, args.file)
-            if not querys:
-                if json_mode:
-                    emit_json({"command": "search", "results": []})
-                else:
-                    print("No queries provided. Please provide at least one query.")
-                return
-
-            # Check cookies validity if provided
-            if args.cookies:
-                check_and_warn_invalid_cookies(args.cookies, quiet=json_mode)
-
-            json_results: list[dict[str, Any]] = []
-
-            for query in querys:
-                if not json_mode:
-                    print(f"Searching {query}...")
-                if args.client in ["chromium", "firefox"]:
-                    raise NotImplementedError(
-                        "Search is currently not available for browser clients."
-                    )
-                else:
-                    if (args.incognito or args.headful) and not json_mode:
-                        print(
-                            "Warning: Incognito and headful mode is only available for browser clients."
-                        )
-
-                    api = PinterestDL.with_api(
-                        timeout=args.timeout,
-                        verbose=args.verbose,
-                        ensure_alt=args.ensure_cap,
-                        dump=args.dump,
-                    ).with_cookies_path(args.cookies)
-
-                    if json_mode and not args.output:
-                        imgs = api.search(
-                            query,
-                            args.num,
-                            min_resolution=parse_resolution(args.resolution)
-                            if args.resolution
-                            else (0, 0),
-                            delay=args.delay,
-                            caption_from_title=args.cap_from_title,
-                        )
-                        write_media_cache(imgs, args.cache)
-                    else:
-                        with scrape_progress(args.num, "Searching", args.verbose or json_mode) as on_progress:
-                            imgs = api.search_and_download(
-                                query,
-                                args.output,
-                                args.num,
-                                download_streams=args.video,
-                                skip_remux=args.skip_remux,
-                                min_resolution=parse_resolution(args.resolution)
-                                if args.resolution
-                                else (0, 0),
-                                cache_path=args.cache,
-                                caption=args.caption,
-                                delay=args.delay,
-                                caption_from_title=args.cap_from_title,
-                                on_progress=on_progress,
-                            )
-                    if not json_mode and imgs and len(imgs) != args.num:
-                        print(
-                            f"Warning: Only ({len(imgs)}) images were successfully downloaded from {query} (requested: {args.num}). Some may have been duplicates, filtered, or failed to download."
-                        )
-                if json_mode:
-                    json_results.append({"input": query, "items": media_list_to_dicts(imgs or [])})
-
-            if json_mode:
-                emit_json({"command": "search", "results": json_results})
-            else:
-                print("\nDone.")
+            run_search(args, json_mode)
         elif args.cmd == "download":
-            # prepare image url data
-            img_datas = io.read_json(args.input)
-            images: List[PinterestMedia] = []
-            for img_data in img_datas if isinstance(img_datas, list) else [img_datas]:
-                img = PinterestMedia.from_dict(img_data)
-                if args.ensure_cap:
-                    if img.alt and img.alt.strip():
-                        images.append(img)
-                else:
-                    images.append(img)
-
-            # download images
-            output_dir = args.output or str(Path(args.input).stem)
-            downloaded_imgs = operations.download_media(
-                images, output_dir, args.video, args.skip_remux
-            )
-
-            # post process
-            kept = operations.prune_images(downloaded_imgs, args.resolution, args.verbose)
-            if args.caption == "txt" or args.caption == "json":
-                operations.add_captions_to_file(
-                    kept,
-                    output_dir,
-                    args.caption,
-                    args.verbose,
-                )
-            elif args.caption == "metadata":
-                operations.add_captions_to_meta(kept, args.verbose)
-            elif args.caption != "none":
-                raise ValueError("Invalid caption mode. Use 'txt', 'json', 'metadata', or 'none'.")
-            if json_mode:
-                emit_json({"command": "download", "input": args.input, "items": media_list_to_dicts(kept)})
-            else:
-                print("\nDone.")
+            run_download(args, json_mode)
         else:
             parser.print_help()
     except KeyboardInterrupt:

--- a/pinterest_dl/domain/browser_cookies.py
+++ b/pinterest_dl/domain/browser_cookies.py
@@ -1,0 +1,86 @@
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+def load_firefox_cookies(domain: Optional[str] = None) -> list[dict]:
+    """Extract cookies from an installed browser's on-disk storage.
+
+    Only Firefox is supported.
+    For Chromium-based browsers, use Playwright's cookie extraction instead.
+
+    _Chromium's App-Bound Encryption (v20, rolling out in 2024) makes direct cookie extraction infeasible._
+
+    Args:
+        domain (str | None, optional): Domain for which to extract cookies. Defaults to None.
+
+    Returns:
+        list[dict]: dicts compatible with CookieJar.from_cookies():
+        [{"name", "value", "domain", "path", "secure", "expiry"}, ...]
+    """
+    db = _find_firefox_db()
+    rows = _query_cookies(db, domain)
+    return [_row_to_dict(row) for row in rows]
+
+
+def _firefox_profiles_root() -> Path:
+    # explicit per-platform root. Avoid leaking `%APPDATA%` onto posix
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            raise FileNotFoundError("APPDATA is not set; cannot locate Firefox profiles.")
+        return Path(appdata) / "Mozilla" / "Firefox" / "Profiles"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Firefox" / "Profiles"
+
+    # assume Linux/Unix
+    return Path.home() / ".mozilla" / "firefox"
+
+
+def _find_firefox_db() -> Path:
+    root = _firefox_profiles_root()
+    if not root.is_dir():
+        raise FileNotFoundError(
+            f"Firefox profiles directory not found at {root}. Is Firefox installed?"
+        )
+
+    # mtime heuristic: most recently used profile = the one logged into
+    dbs = sorted(root.glob("*/cookies.sqlite"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not dbs:
+        raise FileNotFoundError(f"No Firefox cookies.sqlite files found in {root}.")
+    return dbs[0]
+
+
+def _query_cookies(db: Path, domain: Optional[str]) -> list[tuple]:
+    with tempfile.TemporaryDirectory() as tmp:
+        copy = Path(tmp) / "cookies.sqlite"
+        shutil.copy(db, copy)
+        conn = sqlite3.connect(copy)
+        try:
+            sql = "SELECT host, name, value, path, expiry, isSecure FROM moz_cookies"
+            if domain is None:
+                rows = conn.execute(sql).fetchall()
+            else:
+                # match both apex and dot-prefixed host forms
+                rows = conn.execute(
+                    sql + " WHERE host IN (?, ?)", (domain, "." + domain)
+                ).fetchall()
+            return rows
+        finally:
+            conn.close()
+
+
+def _row_to_dict(row: tuple) -> dict:
+    host, name, value, path, expiry, is_secure = row
+    return {
+        "name": name,
+        "value": value,
+        "domain": host,
+        "path": path,
+        "secure": bool(is_secure),
+        "expiry": expiry if expiry else None,  # 0 / NULL session cookies -> None
+    }

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -1,0 +1,161 @@
+"""Tests for Firefox browser cookie extraction."""
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pinterest_dl.domain import browser_cookies
+
+
+def _make_cookie_db(path: Path, rows: list[tuple]) -> None:
+    """Write a minimal Firefox-style cookies.sqlite at path.
+
+    Only the columns the extractor SELECTs are created; a real Firefox schema
+    has more, but the query names columns explicitly so extras are irrelevant.
+    Rows are (host, name, value, path, expiry, isSecure).
+    """
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE moz_cookies "
+            "(host TEXT, name TEXT, value TEXT, path TEXT, expiry INTEGER, isSecure INTEGER)"
+        )
+        conn.executemany(
+            "INSERT INTO moz_cookies (host, name, value, path, expiry, isSecure) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestFindFirefoxDb:
+    """Profile discovery and the mtime heuristic."""
+
+    def test_missing_profile_dir(self, tmp_path, monkeypatch):
+        """FileNotFoundError when the profiles root does not exist."""
+        missing = tmp_path / "no-firefox-here"
+        monkeypatch.setattr(browser_cookies, "_firefox_profiles_root", lambda: missing)
+
+        with pytest.raises(FileNotFoundError, match="profiles directory not found"):
+            browser_cookies._find_firefox_db()
+
+    def test_no_db_in_profiles(self, tmp_path, monkeypatch):
+        """FileNotFoundError when the root exists but holds no cookies.sqlite."""
+        root = tmp_path / "Profiles"
+        (root / "abc.default").mkdir(parents=True)
+        monkeypatch.setattr(browser_cookies, "_firefox_profiles_root", lambda: root)
+
+        with pytest.raises(FileNotFoundError, match="No Firefox cookies.sqlite"):
+            browser_cookies._find_firefox_db()
+
+    def test_picks_highest_mtime(self, tmp_path, monkeypatch):
+        """Returns the cookies.sqlite from the most recently used profile."""
+        root = tmp_path / "Profiles"
+        old_db = root / "old.default" / "cookies.sqlite"
+        new_db = root / "new.default" / "cookies.sqlite"
+        old_db.parent.mkdir(parents=True)
+        new_db.parent.mkdir(parents=True)
+        old_db.touch()
+        new_db.touch()
+        # explicit mtimes so the assertion does not depend on creation order
+        os.utime(old_db, (1000, 1000))
+        os.utime(new_db, (2000, 2000))
+        monkeypatch.setattr(browser_cookies, "_firefox_profiles_root", lambda: root)
+
+        assert browser_cookies._find_firefox_db() == new_db
+
+
+class TestQueryCookies:
+    """SQL extraction against a real on-disk sqlite copy."""
+
+    @pytest.fixture
+    def db(self, tmp_path) -> Path:
+        path = tmp_path / "cookies.sqlite"
+        _make_cookie_db(
+            path,
+            [
+                ("pinterest.com", "a", "1", "/", 111, 1),
+                (".pinterest.com", "b", "2", "/", 222, 0),
+                ("www.pinterest.com", "c", "3", "/", 333, 1),
+                ("google.com", "d", "4", "/", 444, 1),
+            ],
+        )
+        return path
+
+    def test_no_filter_returns_all_rows(self, db):
+        """domain=None returns every row in moz_cookies."""
+        rows = browser_cookies._query_cookies(db, None)
+        assert len(rows) == 4
+
+    def test_domain_filter_matches_apex_and_dot(self, db):
+        """A domain filter matches both 'domain' and '.domain' hosts."""
+        rows = browser_cookies._query_cookies(db, "pinterest.com")
+        hosts = {row[0] for row in rows}
+        # 'www.pinterest.com' is deliberately excluded; only exact + dot-prefixed match
+        assert hosts == {"pinterest.com", ".pinterest.com"}
+
+    def test_domain_filter_excludes_others(self, db):
+        """Unrelated domains are not returned."""
+        rows = browser_cookies._query_cookies(db, "pinterest.com")
+        assert all(row[0] != "google.com" for row in rows)
+
+
+class TestRowToDict:
+    """Row tuple to stored-cookie dict mapping."""
+
+    def test_field_mapping(self):
+        """host -> domain and column order map onto the expected keys."""
+        row = (".pinterest.com", "_auth", "1", "/", 1735689600, 1)
+        assert browser_cookies._row_to_dict(row) == {
+            "name": "_auth",
+            "value": "1",
+            "domain": ".pinterest.com",
+            "path": "/",
+            "secure": True,
+            "expiry": 1735689600,
+        }
+
+    def test_secure_coercion(self):
+        """isSecure integer is coerced to bool."""
+        assert browser_cookies._row_to_dict((".x.com", "n", "v", "/", 1, 0))["secure"] is False
+        assert browser_cookies._row_to_dict((".x.com", "n", "v", "/", 1, 1))["secure"] is True
+
+    def test_session_cookie_expiry_none(self):
+        """expiry == 0 (session cookie) maps to None."""
+        assert browser_cookies._row_to_dict((".x.com", "n", "v", "/", 0, 1))["expiry"] is None
+
+    def test_null_expiry_none(self):
+        """A NULL expiry also maps to None."""
+        assert browser_cookies._row_to_dict((".x.com", "n", "v", "/", None, 1))["expiry"] is None
+
+
+class TestLoadFirefoxCookies:
+    """End-to-end pipeline with discovery stubbed at the db seam."""
+
+    def test_full_pipeline_with_domain_filter(self, tmp_path, monkeypatch):
+        path = tmp_path / "cookies.sqlite"
+        _make_cookie_db(
+            path,
+            [
+                (".pinterest.com", "_auth", "1", "/", 1735689600, 1),
+                ("google.com", "SID", "x", "/", 1735689600, 1),
+            ],
+        )
+        monkeypatch.setattr(browser_cookies, "_find_firefox_db", lambda: path)
+
+        cookies = browser_cookies.load_firefox_cookies(domain="pinterest.com")
+
+        assert cookies == [
+            {
+                "name": "_auth",
+                "value": "1",
+                "domain": ".pinterest.com",
+                "path": "/",
+                "secure": True,
+                "expiry": 1735689600,
+            }
+        ]


### PR DESCRIPTION
## Why

Users already logged into Pinterest in Firefox should not need to re-authenticate through a Playwright session just to capture cookies. This adds a zero-credential path via `pinterest-dl login --from-browser` that reads directly from Firefox's on-disk SQLite database. The same commit set splits the monolithic `main()` dispatch block into named command handlers, reducing the nesting depth that was making the login feature hard to add cleanly.


## CLI

- 0bb45cb - extracts `run_login`, `run_scrape`, `run_search`, `run_download`, `scrape_url_browser`, `scrape_url_api`, and `search_query_api` from the inline dispatch block in `main()`, reducing `main()` to a thin router with no business logic
- 5ef2d8d - adds `--from-browser` flag to the `login` subcommand; when set, skips Playwright entirely and delegates to `load_firefox_cookies(domain="pinterest.com")`
- 5ef2d8d - adds `pinterest_dl/domain/browser_cookies.py` with `load_firefox_cookies()`, `_find_firefox_db()` (mtime heuristic picks the most recently active profile), and `_query_cookies()` (copies the live db to a temp file before opening it to avoid SQLite lock errors)

## Tests

- 27da175 - adds `tests/test_browser_cookies.py` covering profile discovery errors, the mtime heuristic, domain filter correctness, row-to-dict field mapping, and the full end-to-end pipeline via a seeded in-memory SQLite fixture

## Notes

Chromium-based browsers are explicitly unsupported: App-Bound Encryption (rolled out in Chrome v127) makes direct on-disk cookie extraction infeasible without OS-level privilege. The docstring in `browser_cookies.py` documents this so the limitation is visible at the call site rather than only in issues or external docs.

The domain filter in `_query_cookies` matches both `pinterest.com` and `.pinterest.com` host forms, which is how Firefox stores cookies for apex vs. subdomain scope; matching only one form would silently drop half the session cookies.
